### PR TITLE
feat/탐색 기능 추가

### DIFF
--- a/src/main/java/com/anipick/backend/anime/common/dto/AnimeItemDto.java
+++ b/src/main/java/com/anipick/backend/anime/common/dto/AnimeItemDto.java
@@ -1,0 +1,12 @@
+package com.anipick.backend.anime.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AnimeItemDto {
+	private Long id;
+	private String title;
+	private String coverImageUrl;
+}

--- a/src/main/java/com/anipick/backend/anime/common/util/FormatConvert.java
+++ b/src/main/java/com/anipick/backend/anime/common/util/FormatConvert.java
@@ -14,7 +14,9 @@ public class FormatConvert {
 	);
 
 	public static List<String> toConvert(String clientFromType) {
-		if (clientFromType == null) return Collections.emptyList();
+		if (clientFromType == null) {
+			return Collections.emptyList();
+		}
 		return MAP.getOrDefault(clientFromType, Collections.emptyList())
 			.stream()
 			.map(Enum::name)

--- a/src/main/java/com/anipick/backend/anime/common/util/FormatConvert.java
+++ b/src/main/java/com/anipick/backend/anime/common/util/FormatConvert.java
@@ -1,0 +1,23 @@
+package com.anipick.backend.anime.common.util;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.anipick.backend.anime.domain.AnimeFormat;
+
+public class FormatConvert {
+	private static final Map<String, List<AnimeFormat>> MAP = Map.of(
+		"TVA", List.of(AnimeFormat.TV, AnimeFormat.TV_SHORT, AnimeFormat.ONA),
+		"OVA", List.of(AnimeFormat.OVA, AnimeFormat.SPECIAL),
+		"극장판", List.of(AnimeFormat.MOVIE)
+	);
+
+	public static List<String> toConvert(String clientFromType) {
+		if (clientFromType == null) return Collections.emptyList();
+		return MAP.getOrDefault(clientFromType, Collections.emptyList())
+			.stream()
+			.map(Enum::name)
+			.toList();
+	}
+}

--- a/src/main/java/com/anipick/backend/common/domain/SortOption.java
+++ b/src/main/java/com/anipick/backend/common/domain/SortOption.java
@@ -1,0 +1,35 @@
+package com.anipick.backend.common.domain;
+
+import com.anipick.backend.common.exception.CustomException;
+import com.anipick.backend.common.exception.ErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SortOption {
+	LATEST("latest", "a.anime_id DESC"),
+	POPULARITY("popularity", "pao.popularity_anime_order_id ASC"),
+	START_DATE("startDate", "a.start_date ASC"),
+	RATING_DESC("ratingDesc", "r.rating DESC"),
+	RATING_ASC("ratingAsc", "r.rating ASC"),
+	LIKES("likes", "r.like_count DESC"),
+	RATING("rating", "a.average_score DESC");
+
+	private final String code;
+	private final String orderByQuery;
+
+	public static SortOption of(String code) {
+		return switch (code) {
+			case "latest" -> LATEST;
+			case "popularity" -> POPULARITY;
+			case "startDate" -> START_DATE;
+			case "ratingDesc" -> RATING_DESC;
+			case "ratingAsc" -> RATING_ASC;
+			case "likes" -> LIKES;
+			case "rating" -> RATING;
+			default -> throw new CustomException(ErrorCode.BAD_REQUEST);
+		};
+	}
+}

--- a/src/main/java/com/anipick/backend/common/dto/CursorDto.java
+++ b/src/main/java/com/anipick/backend/common/dto/CursorDto.java
@@ -1,25 +1,37 @@
 package com.anipick.backend.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class CursorDto {
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private String sort;
-    private Long lastId;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private String sort;
+	private Long lastId;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private String lastValue;
 
-    public CursorDto(Long lastId) {
-        this.lastId = lastId;
-    }
+	public CursorDto(Long lastId) {
+		this.lastId = lastId;
+	}
 
-    public static CursorDto of(Long lastId) {
-        return new CursorDto(lastId);
-    }
+	public CursorDto(String sort, Long lastId) {
+		this.sort = sort;
+		this.lastId = lastId;
+	}
 
-    public static CursorDto of(String sort, Long lastId) {
-        return new CursorDto(sort, lastId);
-    }
+	public static CursorDto of(Long lastId) {
+		return new CursorDto(lastId);
+	}
+
+	public static CursorDto of(String sort, Long lastId) {
+		return new CursorDto(sort, lastId);
+	}
+
+	public static CursorDto of(String sort, Long lastId, String lastValue) {
+		return new CursorDto(sort, lastId, lastValue);
+	}
 }

--- a/src/main/java/com/anipick/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/anipick/backend/common/exception/ErrorCode.java
@@ -39,7 +39,11 @@ public enum ErrorCode {
 	/**
 	 * Server Errors
 	 */
-	INTERNAL_SERVER_ERROR(500, "서버 오류", "서버에 문제가 발생했습니다.");
+	INTERNAL_SERVER_ERROR(500, "서버 오류", "서버에 문제가 발생했습니다."),
+	/**
+	 * Anime Explore
+	 */
+	EMPTY_YEAR(601, "년도를 입력하지 않음", "년도를 입력해 주세요.");
 
 	private final int code;
 	private final String errorReason;

--- a/src/main/java/com/anipick/backend/explore/controller/ExploreController.java
+++ b/src/main/java/com/anipick/backend/explore/controller/ExploreController.java
@@ -1,0 +1,45 @@
+package com.anipick.backend.explore.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.anipick.backend.common.dto.ApiResponse;
+import com.anipick.backend.common.exception.ErrorCode;
+import com.anipick.backend.explore.domain.GenresOption;
+import com.anipick.backend.explore.dto.ExplorePageDto;
+import com.anipick.backend.explore.service.ExploreService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/explore/animes")
+@RequiredArgsConstructor
+public class ExploreController {
+	private final ExploreService exploreService;
+
+	@GetMapping
+	public ApiResponse<ExplorePageDto> explore(
+		@RequestParam(value = "year", required = false) Integer year,
+		@RequestParam(value = "season", required = false) Integer season,
+		@RequestParam(value = "genres", required = false) List<Long> genres,
+		@RequestParam(value = "genreOp", defaultValue = "OR") GenresOption genreOp,
+		@RequestParam(value = "type", required = false) String type,
+		@RequestParam(value = "sort", defaultValue = "popularity") String sort,
+		@RequestParam(value = "lastId", required = false) Long lastId,
+		@RequestParam(value = "lastValue", required = false) Integer lastValue,
+		@RequestParam(value = "size", defaultValue = "18") int size
+	) {
+		// TODO: JWT 연동 후 실제 user parameter 추가
+		if (year == null && season != null) {
+			return ApiResponse.error(ErrorCode.EMPTY_YEAR);
+		}
+		ExplorePageDto page = exploreService.explore(
+			year, season, genres, genreOp, type, sort, lastId, lastValue, size
+		);
+		return ApiResponse.success(page);
+	}
+}

--- a/src/main/java/com/anipick/backend/explore/domain/GenresOption.java
+++ b/src/main/java/com/anipick/backend/explore/domain/GenresOption.java
@@ -1,0 +1,8 @@
+package com.anipick.backend.explore.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum GenresOption {
+	AND, OR;
+}

--- a/src/main/java/com/anipick/backend/explore/dto/ExploreItemDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/ExploreItemDto.java
@@ -10,4 +10,5 @@ public class ExploreItemDto {
 	private String  title;
 	private String  coverImageUrl;
 	private Integer averageScore;
+	private Long popularId;
 }

--- a/src/main/java/com/anipick/backend/explore/dto/ExploreItemDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/ExploreItemDto.java
@@ -1,0 +1,13 @@
+package com.anipick.backend.explore.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ExploreItemDto {
+	private Long    id;
+	private String  title;
+	private String  coverImageUrl;
+	private Integer averageScore;
+}

--- a/src/main/java/com/anipick/backend/explore/dto/ExplorePageDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/ExplorePageDto.java
@@ -1,0 +1,20 @@
+package com.anipick.backend.explore.dto;
+
+import com.anipick.backend.anime.common.dto.AnimeItemDto;
+import com.anipick.backend.common.dto.CursorDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ExplorePageDto {
+	private Long count;
+	private CursorDto cursor;
+	private List<AnimeItemDto> animes;
+
+	public static ExplorePageDto of(Long count, CursorDto cursor, List<AnimeItemDto> animes) {
+		return new ExplorePageDto(count, cursor, animes);
+	}
+}

--- a/src/main/java/com/anipick/backend/explore/dto/ExploreRequestDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/ExploreRequestDto.java
@@ -1,0 +1,28 @@
+package com.anipick.backend.explore.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExploreRequestDto {
+    private Integer year;
+    private Integer season;
+    private List<Long> genres;
+    private Integer genresSize;
+    private String genreOp;
+    private List<String> types;
+    private Integer typeConvertSize;
+    private String type;
+    private String sort;
+    private String orderByQuery;
+    private Long lastId;
+    private Integer lastValue;
+    private int size;
+}

--- a/src/main/java/com/anipick/backend/explore/mapper/ExploreMapper.java
+++ b/src/main/java/com/anipick/backend/explore/mapper/ExploreMapper.java
@@ -1,0 +1,38 @@
+package com.anipick.backend.explore.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import com.anipick.backend.explore.dto.ExploreItemDto;
+
+@Mapper
+public interface ExploreMapper {
+	long countExplored(
+		@Param(value = "year") Integer year,
+		@Param(value = "season") Integer season,
+		@Param(value = "genres") List<Long> genres,
+		@Param(value = "genresSize") int genresSize,
+		@Param(value = "types") List<String> types,
+		@Param(value = "typeConvertSize") Integer typeConvertSize,
+		@Param(value = "genreOp") String genreOp,
+		@Param(value = "type") String type
+	);
+
+	List<ExploreItemDto> selectExplored(
+		@Param(value = "year") Integer year,
+		@Param(value = "season") Integer season,
+		@Param(value = "genres") List<Long> genres,
+		@Param(value = "genresSize") int genresSize,
+		@Param(value = "types") List<String> types,
+		@Param(value = "typeConvertSize") Integer typeConvertSize,
+		@Param(value = "genreOp") String genreOp,
+		@Param(value = "type") String type,
+		@Param(value = "sort") String sort,
+		@Param(value = "orderByQuery") String orderByQuery,
+		@Param(value = "lastId") Long lastId,
+		@Param(value = "lastValue") Integer lastValue,
+		@Param(value = "size") int size
+	);
+}

--- a/src/main/java/com/anipick/backend/explore/mapper/ExploreMapper.java
+++ b/src/main/java/com/anipick/backend/explore/mapper/ExploreMapper.java
@@ -1,38 +1,14 @@
 package com.anipick.backend.explore.mapper;
 
-import java.util.List;
-
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
-
 import com.anipick.backend.explore.dto.ExploreItemDto;
+import com.anipick.backend.explore.dto.ExploreRequestDto;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
 
 @Mapper
 public interface ExploreMapper {
-	long countExplored(
-		@Param(value = "year") Integer year,
-		@Param(value = "season") Integer season,
-		@Param(value = "genres") List<Long> genres,
-		@Param(value = "genresSize") int genresSize,
-		@Param(value = "types") List<String> types,
-		@Param(value = "typeConvertSize") Integer typeConvertSize,
-		@Param(value = "genreOp") String genreOp,
-		@Param(value = "type") String type
-	);
+    long countExplored(ExploreRequestDto exploreRequestDto);
 
-	List<ExploreItemDto> selectExplored(
-		@Param(value = "year") Integer year,
-		@Param(value = "season") Integer season,
-		@Param(value = "genres") List<Long> genres,
-		@Param(value = "genresSize") int genresSize,
-		@Param(value = "types") List<String> types,
-		@Param(value = "typeConvertSize") Integer typeConvertSize,
-		@Param(value = "genreOp") String genreOp,
-		@Param(value = "type") String type,
-		@Param(value = "sort") String sort,
-		@Param(value = "orderByQuery") String orderByQuery,
-		@Param(value = "lastId") Long lastId,
-		@Param(value = "lastValue") Integer lastValue,
-		@Param(value = "size") int size
-	);
+    List<ExploreItemDto> selectExplored(ExploreRequestDto exploreRequestDto);
 }

--- a/src/main/java/com/anipick/backend/explore/service/ExploreService.java
+++ b/src/main/java/com/anipick/backend/explore/service/ExploreService.java
@@ -1,0 +1,78 @@
+package com.anipick.backend.explore.service;
+
+import com.anipick.backend.anime.common.dto.AnimeItemDto;
+import com.anipick.backend.anime.common.util.FormatConvert;
+import com.anipick.backend.common.domain.SortOption;
+import com.anipick.backend.common.dto.CursorDto;
+import com.anipick.backend.explore.domain.GenresOption;
+import com.anipick.backend.explore.dto.ExploreItemDto;
+import com.anipick.backend.explore.dto.ExplorePageDto;
+import com.anipick.backend.explore.mapper.ExploreMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExploreService {
+	private final ExploreMapper mapper;
+
+	public ExplorePageDto explore(
+		Integer year, Integer season,
+		List<Long> genres, GenresOption genreOp,
+		String type, String sort,
+		Long lastId, Integer lastValue,
+		int size
+	) {
+		log.info(
+			"Anime Explore log : 년도={}, 분기={}, 장르 ID={}, 장르 옵션={}, 타입={}, 정렬={}, 마지막 ID={}, 마지막 값={}, 페이지 크기={}",
+			year, season, genres, genreOp, type, sort, lastId, lastValue, size
+		);
+		int genresSize = genres == null ? 0 : genres.size();
+
+		List<String> convert = FormatConvert.toConvert(type);
+		int typeConvertSize = convert.size();
+
+		SortOption sortOption = SortOption.of(sort);
+		String orderByQuery = sortOption.getOrderByQuery();
+
+		String genreOpName = genreOp.name();
+
+		long total = mapper.countExplored(
+			year, season,
+			genres, genresSize,
+			convert, typeConvertSize,
+			genreOpName, type);
+
+		List<ExploreItemDto> internal = mapper.selectExplored(
+			year, season,
+			genres, genresSize,
+			convert, typeConvertSize,
+			genreOpName, type,
+			sort, orderByQuery,
+			lastId, lastValue,
+			size);
+
+
+		int lastIndex = internal.size() - 1;
+		Long nextId = internal.isEmpty() ? null : internal.get(lastIndex).getId();
+		Integer nextValue = (!"rating".equalsIgnoreCase(sort) || internal.isEmpty())
+			? null : internal.get(lastIndex).getAverageScore();
+
+		String nextValStr = nextValue != null ? nextValue.toString() : null;
+
+		CursorDto cursor = CursorDto.of(sort, nextId, nextValStr);
+
+		List<AnimeItemDto> responseItems = internal.stream()
+			.map(e -> new AnimeItemDto(e.getId(), e.getTitle(), e.getCoverImageUrl()))
+			.collect(Collectors.toList());
+
+		return ExplorePageDto.of(total, cursor, responseItems);
+	}
+}

--- a/src/main/java/com/anipick/backend/explore/service/ExploreService.java
+++ b/src/main/java/com/anipick/backend/explore/service/ExploreService.java
@@ -61,11 +61,27 @@ public class ExploreService {
 
 
 		int lastIndex = internal.size() - 1;
-		Long nextId = internal.isEmpty() ? null : internal.get(lastIndex).getId();
-		Integer nextValue = (!"rating".equalsIgnoreCase(sort) || internal.isEmpty())
-			? null : internal.get(lastIndex).getAverageScore();
 
-		String nextValStr = nextValue != null ? nextValue.toString() : null;
+		Long nextId;
+		if (internal.isEmpty()) {
+			nextId = null;
+		} else {
+			nextId = internal.get(lastIndex).getId();
+		}
+
+		Integer nextValue;
+		if (!"rating".equalsIgnoreCase(sort) || internal.isEmpty()) {
+			nextValue = null;
+		} else {
+			nextValue = internal.get(lastIndex).getAverageScore();
+		}
+
+		String nextValStr;
+		if (nextValue != null) {
+			nextValStr = nextValue.toString();
+		} else {
+			nextValStr = null;
+		}
 
 		CursorDto cursor = CursorDto.of(sort, nextId, nextValStr);
 

--- a/src/main/java/com/anipick/backend/explore/service/ExploreService.java
+++ b/src/main/java/com/anipick/backend/explore/service/ExploreService.java
@@ -30,7 +30,7 @@ public class ExploreService {
 		Long lastId, Integer lastValue,
 		int size
 	) {
-		log.info(
+		log.debug(
 			"Anime Explore log : 년도={}, 분기={}, 장르 ID={}, 장르 옵션={}, 타입={}, 정렬={}, 마지막 ID={}, 마지막 값={}, 페이지 크기={}",
 			year, season, genres, genreOp, type, sort, lastId, lastValue, size
 		);

--- a/src/main/java/com/anipick/backend/explore/service/ExploreService.java
+++ b/src/main/java/com/anipick/backend/explore/service/ExploreService.java
@@ -65,6 +65,8 @@ public class ExploreService {
 		Long nextId;
 		if (internal.isEmpty()) {
 			nextId = null;
+		} else if ("popularity".equalsIgnoreCase(sort)){
+			nextId = internal.get(lastIndex).getPopularId();
 		} else {
 			nextId = internal.get(lastIndex).getId();
 		}

--- a/src/main/java/com/anipick/backend/explore/service/ExploreService.java
+++ b/src/main/java/com/anipick/backend/explore/service/ExploreService.java
@@ -7,6 +7,7 @@ import com.anipick.backend.common.dto.CursorDto;
 import com.anipick.backend.explore.domain.GenresOption;
 import com.anipick.backend.explore.dto.ExploreItemDto;
 import com.anipick.backend.explore.dto.ExplorePageDto;
+import com.anipick.backend.explore.dto.ExploreRequestDto;
 import com.anipick.backend.explore.mapper.ExploreMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -34,31 +35,37 @@ public class ExploreService {
 			"Anime Explore log : 년도={}, 분기={}, 장르 ID={}, 장르 옵션={}, 타입={}, 정렬={}, 마지막 ID={}, 마지막 값={}, 페이지 크기={}",
 			year, season, genres, genreOp, type, sort, lastId, lastValue, size
 		);
+
 		int genresSize = genres == null ? 0 : genres.size();
 
-		List<String> convert = FormatConvert.toConvert(type);
-		int typeConvertSize = convert.size();
+        List<String> convert = FormatConvert.toConvert(type);
 
-		SortOption sortOption = SortOption.of(sort);
-		String orderByQuery = sortOption.getOrderByQuery();
+        int typeConvertSize = convert.size();
 
-		String genreOpName = genreOp.name();
+        SortOption sortOption = SortOption.of(sort);
+        String orderByQuery = sortOption.getOrderByQuery();
 
-		long total = mapper.countExplored(
-			year, season,
-			genres, genresSize,
-			convert, typeConvertSize,
-			genreOpName, type);
+        String genreOpName = genreOp.name();
 
-		List<ExploreItemDto> internal = mapper.selectExplored(
-			year, season,
-			genres, genresSize,
-			convert, typeConvertSize,
-			genreOpName, type,
-			sort, orderByQuery,
-			lastId, lastValue,
-			size);
+        ExploreRequestDto exploreRequestDto = ExploreRequestDto.builder()
+                .year(year)
+                .season(season)
+                .genres(genres)
+                .genresSize(genresSize)
+                .genreOp(genreOpName)
+                .types(convert)
+                .typeConvertSize(typeConvertSize)
+                .type(type)
+                .sort(sort)
+                .orderByQuery(orderByQuery)
+                .lastId(lastId)
+                .lastValue(lastValue)
+                .size(size)
+                .build();
 
+        long total = mapper.countExplored(exploreRequestDto);
+
+        List<ExploreItemDto> internal = mapper.selectExplored(exploreRequestDto);
 
 		int lastIndex = internal.size() - 1;
 

--- a/src/main/resources/mapper/explore/ExploreQueryMapper.xml
+++ b/src/main/resources/mapper/explore/ExploreQueryMapper.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.anipick.backend.explore.mapper.ExploreMapper">
+
+    <!-- 공통 필터링(년도/분기/타입) -->
+    <sql id="commonFilters">
+        <if test="year != null">AND a.season_year = #{year}</if>
+        <if test="season != null and year != null">AND a.season_int = #{season}</if>
+        <if test="typeConvertSize &gt; 0">
+            AND a.format IN
+            <foreach item="f" collection="types" open="(" separator="," close=")">
+                #{f}
+            </foreach>
+        </if>
+    </sql>
+
+    <!-- 전체 카운터 -->
+    <select id="countExplored" resultType="long">
+        SELECT COUNT(DISTINCT a.anime_id)
+        FROM Anime a
+            <if test="genresSize > 0">
+            <choose>
+            <!-- 옵션 OR 일 경우 -->
+                <when test="genreOp == 'OR'">
+                    JOIN AnimeGenres ag ON ag.anime_id = a.anime_id
+                    AND ag.genre_id IN
+                    <foreach item="g" collection="genres" open="(" separator="," close=")">
+                        #{g}
+                    </foreach>
+                </when>
+            <!-- 옵션 AND 일 경우 -->
+                <otherwise>
+                    JOIN (
+                        SELECT anime_id
+                        FROM AnimeGenres
+                        WHERE genre_id IN
+                        <foreach item="g" collection="genres" open="(" separator="," close=")">
+                            #{g}
+                        </foreach>
+                        GROUP BY anime_id
+                        HAVING COUNT(DISTINCT genre_id) = #{genresSize}
+                    ) ag2 ON ag2.anime_id = a.anime_id
+                </otherwise>
+            </choose>
+        </if>
+        <where>
+            <include refid="commonFilters"/>
+        </where>
+    </select>
+
+    <!-- 탐색 조회 -->
+    <select id="selectExplored" resultType="com.anipick.backend.explore.dto.ExploreItemDto">
+        SELECT
+        a.anime_id        AS id,
+        a.title_kor       AS title,
+        a.cover_image_url AS coverImageUrl,
+        a.average_score   AS averageScore
+        FROM Anime a
+
+        <!-- 장르 필터링 -->
+        <if test="genres != null and genres.size() &gt; 0">
+            <choose>
+                <!-- 옵션 OR 일 경우 -->
+                <when test="genreOp == 'OR'">
+                    JOIN (
+                    SELECT DISTINCT anime_id
+                    FROM AnimeGenres
+                    WHERE genre_id IN
+                    <foreach item="g" collection="genres" open="(" separator="," close=")">
+                        #{g}
+                    </foreach>
+                    ) ag2 ON ag2.anime_id = a.anime_id
+                </when>
+                <!-- 옵션 AND 일 경우 -->
+                <otherwise>
+                    JOIN (
+                    SELECT anime_id
+                    FROM AnimeGenres
+                    WHERE genre_id IN
+                    <foreach item="g" collection="genres" open="(" separator="," close=")">
+                        #{g}
+                    </foreach>
+                    GROUP BY anime_id
+                    HAVING COUNT(DISTINCT genre_id) = #{genresSize}
+                    ) ag2 ON ag2.anime_id = a.anime_id
+                </otherwise>
+            </choose>
+        </if>
+
+        <!-- 커서 / 정렬 조인 / 조건 -->
+        <choose>
+            <!-- 인기순 -->
+            <when test="sort == 'popularity'">
+                JOIN PopularityAnimeOrder pao
+                ON pao.anime_id = a.anime_id
+                <if test="lastId != null">
+                    AND pao.popularity_anime_order_id > #{lastId}
+                </if>
+                <where>1=1<include refid="commonFilters"/></where>
+                ORDER BY ${orderByQuery}
+            </when>
+            <!-- 평점순 -->
+            <otherwise>
+                <where>
+                    <if test="lastValue != null">
+                        ( a.average_score &lt; #{lastValue}
+                        OR (a.average_score = #{lastValue} AND a.anime_id &gt; #{lastId})
+                        )
+                    </if>
+                    <include refid="commonFilters"/>
+                </where>
+                ORDER BY ${orderByQuery}, a.anime_id ASC
+            </otherwise>
+        </choose>
+
+        LIMIT #{size}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/explore/ExploreQueryMapper.xml
+++ b/src/main/resources/mapper/explore/ExploreQueryMapper.xml
@@ -56,7 +56,8 @@
         a.anime_id        AS id,
         a.title_kor       AS title,
         a.cover_image_url AS coverImageUrl,
-        a.average_score   AS averageScore
+        a.average_score   AS averageScore,
+        pao.popularity_anime_order_id AS popularId
         FROM Anime a
 
         <!-- 장르 필터링 -->
@@ -103,6 +104,8 @@
             </when>
             <!-- 평점순 -->
             <otherwise>
+                JOIN PopularityAnimeOrder pao
+                ON pao.anime_id = a.anime_id
                 <where>
                     <if test="lastValue != null">
                         ( a.average_score &lt; #{lastValue}

--- a/src/main/resources/mapper/explore/ExploreQueryMapper.xml
+++ b/src/main/resources/mapper/explore/ExploreQueryMapper.xml
@@ -17,7 +17,9 @@
     </sql>
 
     <!-- 전체 카운터 -->
-    <select id="countExplored" resultType="long">
+    <select id="countExplored"
+            parameterType="com.anipick.backend.explore.dto.ExploreRequestDto"
+            resultType="long">
         SELECT COUNT(DISTINCT a.anime_id)
         FROM Anime a
             <if test="genresSize > 0">
@@ -51,7 +53,9 @@
     </select>
 
     <!-- 탐색 조회 -->
-    <select id="selectExplored" resultType="com.anipick.backend.explore.dto.ExploreItemDto">
+    <select id="selectExplored"
+            parameterType="com.anipick.backend.explore.dto.ExploreRequestDto"
+            resultType="com.anipick.backend.explore.dto.ExploreItemDto">
         SELECT
         a.anime_id        AS id,
         a.title_kor       AS title,

--- a/src/test/java/com/anipick/backend/explore/service/ExploreServiceTest.java
+++ b/src/test/java/com/anipick/backend/explore/service/ExploreServiceTest.java
@@ -1,0 +1,69 @@
+package com.anipick.backend.explore.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.ArgumentMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.anipick.backend.explore.domain.GenresOption;
+import com.anipick.backend.explore.mapper.ExploreMapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExploreServiceTest {
+
+	@Mock
+	private ExploreMapper mapper;
+
+	@InjectMocks
+	private ExploreService service;
+
+	@Captor
+	private ArgumentCaptor<List<String>> formatsCaptor;
+
+	@Test
+	@DisplayName("TYPE Parameter 변환 확인")
+	void typeConversionSuccess() {
+		// given
+		doReturn(List.of())
+			.when(mapper).selectExplored(
+				eq(2024), eq(1), anyList(), eq(1),
+				anyList(), eq(3),
+				eq("OR"), eq("TVA"),
+				eq("popularity"), anyString(),
+				eq(3L), eq(44), eq(5)
+			);
+
+		List<Long> genres = new ArrayList<>();
+		genres.add(3L);
+
+		// when
+		service.explore(
+			2024, 1,
+			genres, GenresOption.OR,
+			"TVA", "popularity",
+			3L, 44,
+			5
+		);
+
+		// then
+		then(mapper).should().selectExplored(
+			eq(2024), eq(1), anyList(), eq(1),
+			formatsCaptor.capture(), eq(3),
+			eq("OR"), eq("TVA"),
+			eq("popularity"), anyString(),
+			eq(3L), eq(44), eq(5)
+		);
+
+		assertThat(formatsCaptor.getValue())
+			.containsExactly("TV", "TV_SHORT", "ONA");
+	}
+}


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->


---

**work-details**

- 애니메이션 탐색 기능 추가
  - 정렬 타입
    - `SortOption` 클래스는 **더이상 정렬의 기능이 추가되지 않을 것**과 **여러 기능에서 사용될 정렬 타입들을 관리**하고자, enum으로 작성하였습니다.
    - orderByQuery  필드는 mapper 에 사용될 값으로, mapper에 매개변수로 넣어서 사용할 수 있습니다.
    - 혹여나 정렬 타입이 추가된다면, 기존에 작성된 정렬타입들처럼 작성하여 추가할 수 있습니다.
    - 다른 정렬 타입이 포함돼 있는 기능들을 구현할 때, SQL 문을 작성함에 따라 orderByQuery 필드의 값이 조금 변경될 가능성이 있습니다.
    - `pao.popularity_anime_order_id ASC` 라고 적은 필드가 있는데요, 해당 테이블을 인기순으로 넣어서 큰 수부터 넣었다는 가정 하에 작성하였습니다. 만약, 반대로 넣어졌을 경우, DESC로 변경해야 합니다.
  - 애니 타입 변환
    - `FormatConvert` 클래스는 DB에 저장되어 있는 포맷 형식들(TV, TV_SHORT.. 등등)을 묶어서, 해당 타입이 포함돼 있는 데이터들을 찾고자 작성하였습니다.



**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

현재 local DB에는 장르 ID를 2와 3을 모두 가진 애니 ID가 1001, 1002가 있습니다.

- 장르 선택 OR일 경우, 인기순 (기본값) - `/api/explore/animes?genres=2,3`
![image](https://github.com/user-attachments/assets/e57ccb1b-f89f-4ce3-a8a6-162341eea688)

- 장르 선택 AND일 경우, 인기순 - `/api/explore/animes?genres=2,3&genreOp=AND`
![image](https://github.com/user-attachments/assets/d911e7ac-26aa-445a-ba7e-4e7308046c63)

- 타입 TVA 선택할 시, 인기순 - `/api/explore/animes?type=극장판`
![image](https://github.com/user-attachments/assets/f978eb87-a6a7-4dc9-bcf3-a9b1b2842475)

- 분기만 선택할 시 - `/api/explore/animes?season=1`
![image](https://github.com/user-attachments/assets/6f43e5a6-3ecc-4c25-a1b0-b0fe0d5b7d22)

- 장르 선택 OR일경우, 평점순 - `/api/explore/animes?genres=2,3&sort=rating&genreOp=OR`
![image](https://github.com/user-attachments/assets/27ef87e6-f2df-43ae-a5aa-a9fe7a883ca4)


### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [x] Test Code
- [x] API Test
