### PR TITLE
fix/시즌 <-> 날짜 컨버터를 이용한 탐색 기능 수정

### DIFF
--- a/src/main/java/com/anipick/backend/anime/domain/SeasonConverter.java
+++ b/src/main/java/com/anipick/backend/anime/domain/SeasonConverter.java
@@ -7,6 +7,9 @@ public class SeasonConverter {
 
     // 년도만 눌렀을 때의 범위 날짜 (탐색용)
     public static RangeDate getYearRangDate(int year) {
+        if (year < 0) {
+            return null;
+        }
         final String startDate = "%d-01-01".formatted(year);
         final String endDate = "%d-12-31".formatted(year);
         return new RangeDate(startDate, endDate);
@@ -14,6 +17,9 @@ public class SeasonConverter {
 
     // 년도+분기 눌렀을 때의 범위 날짜 (탐색용)
     public static RangeDate getRangDate(int year, int quarter) {
+        if (year < 0 || quarter < 0) {
+            return null;
+        }
         final Season nextSeason = Season.getByCode(quarter);
         final int startMonth = nextSeason.getStartMonth().getValue();
         final int endMonth = nextSeason.getEndMonth().getValue();

--- a/src/main/java/com/anipick/backend/explore/dto/ExploreRequestDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/ExploreRequestDto.java
@@ -1,5 +1,6 @@
 package com.anipick.backend.explore.dto;
 
+import com.anipick.backend.anime.domain.RangeDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,8 +13,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExploreRequestDto {
-    private Integer year;
-    private Integer season;
+    private String startDate;
+    private String endDate;
     private List<Long> genres;
     private Integer genresSize;
     private String genreOp;
@@ -25,4 +26,49 @@ public class ExploreRequestDto {
     private Long lastId;
     private Integer lastValue;
     private int size;
+
+    public static ExploreRequestDto of(
+        RangeDate rangeDate,
+        List<Long> genres,
+        Integer genresSize,
+        String genreOp,
+        List<String> types,
+        Integer typeConvertSize,
+        String type,
+        String sort,
+        String orderByQuery,
+        Long lastId,
+        Integer lastValue,
+        int size
+    ) {
+        return new ExploreRequestDto(
+            rangeDate.getStartDate(), rangeDate.getEndDate(),
+            genres, genresSize, genreOp,
+            types, typeConvertSize, type,
+            sort, orderByQuery,
+            lastId, lastValue, size
+        );
+    }
+
+    public static ExploreRequestDto dateNullOf(
+        List<Long> genres,
+        Integer genresSize,
+        String genreOp,
+        List<String> types,
+        Integer typeConvertSize,
+        String type,
+        String sort,
+        String orderByQuery,
+        Long lastId,
+        Integer lastValue,
+        int size
+    ) {
+        return new ExploreRequestDto(
+            null, null,
+            genres, genresSize, genreOp,
+            types, typeConvertSize, type,
+            sort, orderByQuery,
+            lastId, lastValue, size
+        );
+    }
 }

--- a/src/main/java/com/anipick/backend/explore/service/ExploreService.java
+++ b/src/main/java/com/anipick/backend/explore/service/ExploreService.java
@@ -2,6 +2,8 @@ package com.anipick.backend.explore.service;
 
 import com.anipick.backend.anime.common.dto.AnimeItemDto;
 import com.anipick.backend.anime.common.util.FormatConvert;
+import com.anipick.backend.anime.domain.RangeDate;
+import com.anipick.backend.anime.domain.SeasonConverter;
 import com.anipick.backend.common.domain.SortOption;
 import com.anipick.backend.common.dto.CursorDto;
 import com.anipick.backend.explore.domain.GenresOption;
@@ -47,21 +49,9 @@ public class ExploreService {
 
         String genreOpName = genreOp.name();
 
-        ExploreRequestDto exploreRequestDto = ExploreRequestDto.builder()
-                .year(year)
-                .season(season)
-                .genres(genres)
-                .genresSize(genresSize)
-                .genreOp(genreOpName)
-                .types(convert)
-                .typeConvertSize(typeConvertSize)
-                .type(type)
-                .sort(sort)
-                .orderByQuery(orderByQuery)
-                .lastId(lastId)
-                .lastValue(lastValue)
-                .size(size)
-                .build();
+        ExploreRequestDto exploreRequestDto = makeExploreRequestDto(
+				year, season, genres, type, sort, lastId, lastValue, size,
+				genresSize, genreOpName, convert, typeConvertSize, orderByQuery);
 
         long total = mapper.countExplored(exploreRequestDto);
 
@@ -100,4 +90,55 @@ public class ExploreService {
 
 		return ExplorePageDto.of(total, cursor, responseItems);
 	}
+
+	private static ExploreRequestDto makeExploreRequestDto(Integer year, Integer season, List<Long> genres, String type,
+        String sort, Long lastId, Integer lastValue, int size, int genresSize, String genreOpName, List<String> convert,
+        int typeConvertSize, String orderByQuery) {
+        if (year != null && season != null) {
+            RangeDate dateRange = SeasonConverter.getRangDate(year, season);
+            return ExploreRequestDto.of(
+                dateRange,
+                genres,
+                genresSize,
+                genreOpName,
+                convert,
+                typeConvertSize,
+                type,
+                sort,
+                orderByQuery,
+                lastId,
+                lastValue,
+                size
+            );
+        } else if (year != null) {
+            RangeDate dateRange = SeasonConverter.getYearRangDate(year);
+            return ExploreRequestDto.of(
+                dateRange,
+                genres,
+                genresSize,
+                genreOpName,
+                convert,
+                typeConvertSize,
+                type,
+                sort,
+                orderByQuery,
+                lastId,
+                lastValue,
+                size
+            );
+        }
+        return ExploreRequestDto.dateNullOf(
+            genres,
+            genresSize,
+            genreOpName,
+            convert,
+            typeConvertSize,
+            type,
+            sort,
+            orderByQuery,
+            lastId,
+            lastValue,
+            size
+        );
+    }
 }

--- a/src/main/resources/mapper/explore/ExploreQueryMapper.xml
+++ b/src/main/resources/mapper/explore/ExploreQueryMapper.xml
@@ -6,8 +6,9 @@
 
     <!-- 공통 필터링(년도/분기/타입) -->
     <sql id="commonFilters">
-        <if test="year != null">AND a.season_year = #{year}</if>
-        <if test="season != null and year != null">AND a.season_int = #{season}</if>
+        <if test="startDate != null and endDate != null">
+            AND a.start_date BETWEEN #{startDate} AND #{endDate}
+        </if>
         <if test="typeConvertSize &gt; 0">
             AND a.format IN
             <foreach item="f" collection="types" open="(" separator="," close=")">


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 기존은 Anime.season 컬럼과 Anime.year 컬럼을 이용해서 기능 추가
- `12월부터 2월`이 `1분기`로, 사용자에게 분기 관련 혼란을 야기할 가능성이 있기 때문에 시즌<->날짜 컨버터를 사용
- `1월부터 3월`을 `1분기`로 사용, Anime.start_date 컬럼을 이용해 `날짜 범위 검색`으로 변경

---

**work-details**

- 시즌 <-> 날짜 컨버터를 이용해 날짜 범위 검색 쿼리 변경
- DTO 필드 내 year / season 제거 후 시작 날짜 및 마지막 날짜 필드 추가
- year, season 에 대한 null 처리 
  - year + season 값이 있을 경우
  - year 값만 있을 경우
  - 둘 다 없을 경우

- year, season 3가지 null 처리에 대한 케이스들 API 테스트 진행

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test
