### PR TITLE
refactor/dto 레이어 이동

### DIFF
--- a/src/main/java/com/anipick/backend/anime/controller/MetaDataController.java
+++ b/src/main/java/com/anipick/backend/anime/controller/MetaDataController.java
@@ -1,6 +1,6 @@
 package com.anipick.backend.anime.controller;
 
-import com.anipick.backend.anime.dto.MetaDataGroupResultDto;
+import com.anipick.backend.anime.controller.dto.MetaDataGroupResultDto;
 import com.anipick.backend.anime.service.MetaDataService;
 import com.anipick.backend.common.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/anipick/backend/anime/controller/dto/MetaDataGroupResultDto.java
+++ b/src/main/java/com/anipick/backend/anime/controller/dto/MetaDataGroupResultDto.java
@@ -1,6 +1,9 @@
-package com.anipick.backend.anime.dto;
+package com.anipick.backend.anime.controller.dto;
 
 import com.anipick.backend.anime.domain.AnimeFormat;
+import com.anipick.backend.anime.service.dto.GenreDto;
+import com.anipick.backend.anime.service.dto.SeasonDto;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/anipick/backend/anime/mapper/MetaDataMapper.java
+++ b/src/main/java/com/anipick/backend/anime/mapper/MetaDataMapper.java
@@ -1,6 +1,6 @@
 package com.anipick.backend.anime.mapper;
 
-import com.anipick.backend.anime.dto.GenreDto;
+import com.anipick.backend.anime.service.dto.GenreDto;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;

--- a/src/main/java/com/anipick/backend/anime/service/MetaDataService.java
+++ b/src/main/java/com/anipick/backend/anime/service/MetaDataService.java
@@ -2,9 +2,9 @@ package com.anipick.backend.anime.service;
 
 import com.anipick.backend.anime.domain.AnimeFormat;
 import com.anipick.backend.anime.domain.Season;
-import com.anipick.backend.anime.dto.GenreDto;
-import com.anipick.backend.anime.dto.MetaDataGroupResultDto;
-import com.anipick.backend.anime.dto.SeasonDto;
+import com.anipick.backend.anime.service.dto.GenreDto;
+import com.anipick.backend.anime.controller.dto.MetaDataGroupResultDto;
+import com.anipick.backend.anime.service.dto.SeasonDto;
 import com.anipick.backend.anime.mapper.MetaDataMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/anipick/backend/anime/service/dto/GenreDto.java
+++ b/src/main/java/com/anipick/backend/anime/service/dto/GenreDto.java
@@ -1,4 +1,4 @@
-package com.anipick.backend.anime.dto;
+package com.anipick.backend.anime.service.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/anipick/backend/anime/service/dto/SeasonDto.java
+++ b/src/main/java/com/anipick/backend/anime/service/dto/SeasonDto.java
@@ -1,4 +1,4 @@
-package com.anipick.backend.anime.dto;
+package com.anipick.backend.anime.service.dto;
 
 import com.anipick.backend.anime.domain.Season;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/anipick/backend/explore/controller/ExploreController.java
+++ b/src/main/java/com/anipick/backend/explore/controller/ExploreController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.anipick.backend.common.dto.ApiResponse;
 import com.anipick.backend.common.exception.ErrorCode;
 import com.anipick.backend.explore.domain.GenresOption;
-import com.anipick.backend.explore.dto.ExplorePageDto;
+import com.anipick.backend.explore.controller.dto.ExplorePageDto;
 import com.anipick.backend.explore.service.ExploreService;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/anipick/backend/explore/controller/dto/ExplorePageDto.java
+++ b/src/main/java/com/anipick/backend/explore/controller/dto/ExplorePageDto.java
@@ -1,4 +1,4 @@
-package com.anipick.backend.explore.dto;
+package com.anipick.backend.explore.controller.dto;
 
 import com.anipick.backend.anime.common.dto.AnimeItemDto;
 import com.anipick.backend.common.dto.CursorDto;

--- a/src/main/java/com/anipick/backend/explore/mapper/ExploreMapper.java
+++ b/src/main/java/com/anipick/backend/explore/mapper/ExploreMapper.java
@@ -1,7 +1,7 @@
 package com.anipick.backend.explore.mapper;
 
-import com.anipick.backend.explore.dto.ExploreItemDto;
-import com.anipick.backend.explore.dto.ExploreRequestDto;
+import com.anipick.backend.explore.service.dto.ExploreItemDto;
+import com.anipick.backend.explore.service.dto.ExploreRequestDto;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;

--- a/src/main/java/com/anipick/backend/explore/service/ExploreService.java
+++ b/src/main/java/com/anipick/backend/explore/service/ExploreService.java
@@ -7,9 +7,9 @@ import com.anipick.backend.anime.domain.SeasonConverter;
 import com.anipick.backend.common.domain.SortOption;
 import com.anipick.backend.common.dto.CursorDto;
 import com.anipick.backend.explore.domain.GenresOption;
-import com.anipick.backend.explore.dto.ExploreItemDto;
-import com.anipick.backend.explore.dto.ExplorePageDto;
-import com.anipick.backend.explore.dto.ExploreRequestDto;
+import com.anipick.backend.explore.service.dto.ExploreItemDto;
+import com.anipick.backend.explore.controller.dto.ExplorePageDto;
+import com.anipick.backend.explore.service.dto.ExploreRequestDto;
 import com.anipick.backend.explore.mapper.ExploreMapper;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/anipick/backend/explore/service/dto/ExploreItemDto.java
+++ b/src/main/java/com/anipick/backend/explore/service/dto/ExploreItemDto.java
@@ -1,4 +1,4 @@
-package com.anipick.backend.explore.dto;
+package com.anipick.backend.explore.service.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/anipick/backend/explore/service/dto/ExploreRequestDto.java
+++ b/src/main/java/com/anipick/backend/explore/service/dto/ExploreRequestDto.java
@@ -1,4 +1,4 @@
-package com.anipick.backend.explore.dto;
+package com.anipick.backend.explore.service.dto;
 
 import com.anipick.backend.anime.domain.RangeDate;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/anipick/backend/review/controller/ReviewController.java
+++ b/src/main/java/com/anipick/backend/review/controller/ReviewController.java
@@ -1,7 +1,7 @@
 package com.anipick.backend.review.controller;
 
 import com.anipick.backend.common.dto.ApiResponse;
-import com.anipick.backend.review.dto.RecentReviewPageDto;
+import com.anipick.backend.review.controller.dto.RecentReviewPageDto;
 import com.anipick.backend.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/anipick/backend/review/controller/dto/RecentReviewPageDto.java
+++ b/src/main/java/com/anipick/backend/review/controller/dto/RecentReviewPageDto.java
@@ -1,6 +1,8 @@
-package com.anipick.backend.review.dto;
+package com.anipick.backend.review.controller.dto;
 
 import com.anipick.backend.common.dto.CursorDto;
+import com.anipick.backend.review.service.dto.RecentReviewItemDto;
+
 import lombok.*;
 
 import java.util.List;

--- a/src/main/java/com/anipick/backend/review/mapper/RecentReviewMapper.java
+++ b/src/main/java/com/anipick/backend/review/mapper/RecentReviewMapper.java
@@ -1,6 +1,6 @@
 package com.anipick.backend.review.mapper;
 
-import com.anipick.backend.review.dto.RecentReviewItemDto;
+import com.anipick.backend.review.service.dto.RecentReviewItemDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 

--- a/src/main/java/com/anipick/backend/review/service/ReviewService.java
+++ b/src/main/java/com/anipick/backend/review/service/ReviewService.java
@@ -1,8 +1,8 @@
 package com.anipick.backend.review.service;
 
 import com.anipick.backend.common.dto.CursorDto;
-import com.anipick.backend.review.dto.RecentReviewItemDto;
-import com.anipick.backend.review.dto.RecentReviewPageDto;
+import com.anipick.backend.review.service.dto.RecentReviewItemDto;
+import com.anipick.backend.review.controller.dto.RecentReviewPageDto;
 import com.anipick.backend.review.mapper.RecentReviewMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/anipick/backend/review/service/dto/RecentReviewItemDto.java
+++ b/src/main/java/com/anipick/backend/review/service/dto/RecentReviewItemDto.java
@@ -1,4 +1,4 @@
-package com.anipick.backend.review.dto;
+package com.anipick.backend.review.service.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/anipick/backend/user/controller/UserController.java
+++ b/src/main/java/com/anipick/backend/user/controller/UserController.java
@@ -2,7 +2,7 @@ package com.anipick.backend.user.controller;
 
 import com.anipick.backend.common.dto.ApiResponse;
 import com.anipick.backend.user.domain.User;
-import com.anipick.backend.user.dto.SignUpRequest;
+import com.anipick.backend.user.controller.dto.SignUpRequest;
 import com.anipick.backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/anipick/backend/user/controller/dto/SignUpRequest.java
+++ b/src/main/java/com/anipick/backend/user/controller/dto/SignUpRequest.java
@@ -1,4 +1,4 @@
-package com.anipick.backend.user.dto;
+package com.anipick.backend.user.controller.dto;
 
 import lombok.Getter;
 

--- a/src/main/java/com/anipick/backend/user/service/UserService.java
+++ b/src/main/java/com/anipick/backend/user/service/UserService.java
@@ -6,7 +6,7 @@ import com.anipick.backend.common.exception.ErrorCode;
 import com.anipick.backend.user.domain.LoginFormat;
 import com.anipick.backend.user.domain.User;
 import com.anipick.backend.user.domain.UserDefaults;
-import com.anipick.backend.user.dto.SignUpRequest;
+import com.anipick.backend.user.controller.dto.SignUpRequest;
 import com.anipick.backend.user.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/resources/mapper/anime/MetaDataQueryMapper.xml
+++ b/src/main/resources/mapper/anime/MetaDataQueryMapper.xml
@@ -4,7 +4,7 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.anipick.backend.anime.mapper.MetaDataMapper">
-    <select id="selectAllGenres" resultType="com.anipick.backend.anime.dto.GenreDto">
+    <select id="selectAllGenres" resultType="com.anipick.backend.anime.service.dto.GenreDto">
         SELECT genre_id AS id, genre_kor AS name
         FROM Genres
         ORDER BY genre_id

--- a/src/main/resources/mapper/explore/ExploreQueryMapper.xml
+++ b/src/main/resources/mapper/explore/ExploreQueryMapper.xml
@@ -19,7 +19,7 @@
 
     <!-- 전체 카운터 -->
     <select id="countExplored"
-            parameterType="com.anipick.backend.explore.dto.ExploreRequestDto"
+            parameterType="com.anipick.backend.explore.service.dto.ExploreRequestDto"
             resultType="long">
         SELECT COUNT(DISTINCT a.anime_id)
         FROM Anime a
@@ -55,8 +55,8 @@
 
     <!-- 탐색 조회 -->
     <select id="selectExplored"
-            parameterType="com.anipick.backend.explore.dto.ExploreRequestDto"
-            resultType="com.anipick.backend.explore.dto.ExploreItemDto">
+            parameterType="com.anipick.backend.explore.service.dto.ExploreRequestDto"
+            resultType="com.anipick.backend.explore.service.dto.ExploreItemDto">
         SELECT
         a.anime_id        AS id,
         a.title_kor       AS title,

--- a/src/main/resources/mapper/review/ReviewQueryMapper.xml
+++ b/src/main/resources/mapper/review/ReviewQueryMapper.xml
@@ -19,7 +19,7 @@
           AND R.is_spoiler = false
     </select>
 
-    <select id="selectRecentReviews" resultType="com.anipick.backend.review.dto.RecentReviewItemDto">
+    <select id="selectRecentReviews" resultType="com.anipick.backend.review.service.dto.RecentReviewItemDto">
         SELECT
             r.review_id AS reviewId,
             r.anime_id AS animeId,

--- a/src/test/java/com/anipick/backend/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/anipick/backend/review/service/ReviewServiceTest.java
@@ -1,7 +1,7 @@
 package com.anipick.backend.review.service;
 
-import com.anipick.backend.review.dto.RecentReviewItemDto;
-import com.anipick.backend.review.dto.RecentReviewPageDto;
+import com.anipick.backend.review.service.dto.RecentReviewItemDto;
+import com.anipick.backend.review.controller.dto.RecentReviewPageDto;
 import com.anipick.backend.review.mapper.RecentReviewMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 이전에는 도메인 마다 dto 디렉토리 안에 해당 dto들이 관리돼있었음.
- 추후에 dto가 많아짐에 따라, 해당 dto가 어디 레이어에 쓰이는지 헷갈릴 뿐더러, 관리하기 어려워질 것으로 예상
- controller 단과 service 단의 dto로 분리하였고, 공용으로 쓰일 dto는 domain 안에 common.dto 같은 패키지로 관리

---

**work-details**

- 도메인 dto에서 controller / service dto로 나눠서 관리합니다. 
- anime의 common.dto 같은 경우 공용으로 쓰일 dto가 몇 개 존재할 것으로 예상되어, common으로 관리합니다.
- 이처럼 해당 도메인에서 공용으로 쓰일 것들은 common 디렉토리를 생성해 사용합니다.
  - 아마 애니 도메인 쪽 말고는 다른 곳에선 크게 없을 것 같긴 합니다.

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test
