### PR TITLE
Fix/format, 공개예정 메서드 list 변경, 최근 리뷰 조회 수정

### DIFF
--- a/src/main/java/com/anipick/backend/anime/domain/AnimeFormat.java
+++ b/src/main/java/com/anipick/backend/anime/domain/AnimeFormat.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AnimeFormat {
-    TV, TV_SHORT, MOVIE, SPECIAL, OVA, ONA, MUSIC, ONE_SHOT;
+    TV, TV_SHORT, MOVIE, SPECIAL, OVA, ONA;
 }

--- a/src/main/java/com/anipick/backend/anime/service/AnimeService.java
+++ b/src/main/java/com/anipick/backend/anime/service/AnimeService.java
@@ -104,7 +104,7 @@ public class AnimeService {
 		if (items.isEmpty()) {
 			nextId = null;
 		} else {
-			nextId = items.get(items.size() - 1).getAnimeId();
+			nextId = items.getLast().getAnimeId();
 		}
 
 		CursorDto cursor = CursorDto.of(sort, nextId, null);
@@ -123,7 +123,7 @@ public class AnimeService {
 		if (imgFilterItems.isEmpty()) {
 			nextId = null;
 		} else {
-			nextId = imgFilterItems.get(imgFilterItems.size() - 1).getPopularId();
+			nextId = imgFilterItems.getLast().getPopularId();
 		}
 
 		List<ComingSoonItemDto> items = imgFilterItems.stream()
@@ -151,8 +151,7 @@ public class AnimeService {
 		if (imgFilterItems.isEmpty()) {
 			nextValue = null;
 		} else {
-			int lastIndex = imgFilterItems.size() - 1;
-			nextValue = imgFilterItems.get(lastIndex).getStartDate();
+			nextValue = imgFilterItems.getLast().getStartDate();
 		}
 
 		List<ComingSoonItemBasicDto> typeCovertAnimes = imgFilterItems.stream()
@@ -174,8 +173,7 @@ public class AnimeService {
 		if (starDateSortAnimes.isEmpty()) {
 			nextId = null;
 		} else {
-			int lastIndex = imgFilterItems.size() - 1;
-			nextId = imgFilterItems.get(lastIndex).getAnimeId();
+			nextId = imgFilterItems.getLast().getAnimeId();
 		}
 		CursorDto cursor = CursorDto.of(sort, nextId, nextValue);
 		return ComingSoonPageDto.of(totalCount, cursor, items);

--- a/src/main/resources/mapper/review/ReviewQueryMapper.xml
+++ b/src/main/resources/mapper/review/ReviewQueryMapper.xml
@@ -16,7 +16,8 @@
                           FROM BlockedUser bu
                           WHERE bu.blocked_user_id = r.user_id
                             AND bu.user_id = #{currentUserId})
-          AND R.is_spoiler = false
+          AND r.is_spoiler = false
+          AND r.content IS NOT NULL
     </select>
 
     <select id="selectRecentReviews" resultType="com.anipick.backend.review.dto.RecentReviewItemDto">
@@ -45,6 +46,7 @@
         AND rl.user_id = #{currentUserId}
 
         WHERE r.is_spoiler = FALSE
+        AND r.content IS NOT NULL
         -- 신고된 리뷰는 제외
         AND NOT EXISTS (
             SELECT 1 FROM ReportedReview rr


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

1. 안 쓰이는 format(MUSIC, ONE_SHOT)이 있습니다. 뮤직비디오와 만화 한 장을 뜻하는데, 프로젝트에 활용되지 않아 삭제합니다.
2. 공개 예정 기능의 메서드 내에서 lastId 값을 구하는 로직이 있습니다. 기존에는 list size 마지막 단을 찍어서 조회했는데, getLast() 메서드를 이용해서 변경합니다. 
3. 최근 리뷰 조회는 '리뷰' 만을 조회합니다. 기존에는 '평가'도 같이 조회했습니다. `Review.content is not null`을 추가해, '리뷰'만을 조회합니다.

---

**work-details**

- AnimeFormat 내 `MUSIC`, `ONE_SHOT` 제거
- 공개예정 메서드 내 lastId 로직 get().(size() - 1) -> getLast()
- 최근 리뷰 조회 쿼리 where 조건에 `content is not null` 추가

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
