### PR TITLE
fix/33 local 로그아웃 기능 추가 및 JWTAuthFilter 수정

### DIFF
--- a/src/main/java/com/anipick/backend/common/auth/JwtAuthFilter.java
+++ b/src/main/java/com/anipick/backend/common/auth/JwtAuthFilter.java
@@ -43,7 +43,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 String emailFromToken = jwtTokenProvider.getEmailFromToken(accessToken);
 
                 UserDetails userDetails = userDetailsService.loadUserByUsername(emailFromToken);
-                log.info("Authorities found: {}", userDetails.getAuthorities());
                 Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
@@ -52,7 +51,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         } catch (Exception e) {
             log.error(e.getMessage());
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
-            response.setContentType("application/json");
+            response.setContentType("application/json;charset=UTF-8");
 
             ApiResponse<Object> apiResponse = ApiResponse.error(ErrorCode.REQUESTED_TOKEN_INVALID);
             ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/com/anipick/backend/common/auth/JwtAuthFilter.java
+++ b/src/main/java/com/anipick/backend/common/auth/JwtAuthFilter.java
@@ -41,7 +41,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             if(accessToken != null) {
                 jwtTokenProvider.validateToken(accessToken); //토큰 유효성 검사
 
-                String checkLogout = redisTemplate.opsForValue().get(UserDefaults.DEFAULT_BLACKLIST_FORMAT + accessToken);
+                String checkLogout = redisTemplate.opsForValue().get(UserDefaults.DEFAULT_LOGOUT_LIST_FORMAT + accessToken);
                 if(checkLogout != null) {
                     response.setStatus(HttpStatus.UNAUTHORIZED.value());
                     response.setContentType("application/json;charset=UTF-8");

--- a/src/main/java/com/anipick/backend/common/auth/JwtTokenProvider.java
+++ b/src/main/java/com/anipick/backend/common/auth/JwtTokenProvider.java
@@ -4,6 +4,7 @@ import com.anipick.backend.common.exception.CustomException;
 import com.anipick.backend.common.exception.ErrorCode;
 import io.jsonwebtoken.*;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -15,7 +16,10 @@ import java.util.Date;
 @Component
 public class JwtTokenProvider {
     private final String secretKey;
+
+    @Getter
     private final int accessTokenExpiration;
+    @Getter
     private final int refreshTokenExpiration;
 
     public JwtTokenProvider(
@@ -65,7 +69,10 @@ public class JwtTokenProvider {
 
     public void validateToken(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(jwtSecretKey()).build().parseClaimsJws(token);
+            Jwts.parserBuilder()
+                    .setSigningKey(jwtSecretKey())
+                    .build()
+                    .parseClaimsJws(token);
         } catch (ExpiredJwtException e) {
             throw new CustomException(ErrorCode.EXPIRED_TOKEN);
         } catch (JwtException | IllegalArgumentException e) {

--- a/src/main/java/com/anipick/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/anipick/backend/common/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.anipick.backend.common.auth.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -26,6 +27,7 @@ import java.util.Arrays;
 public class SecurityConfig {
     private final CustomUserDetailsService userDetailsService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
@@ -44,7 +46,7 @@ public class SecurityConfig {
                         session ->
                                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
-                .addFilterBefore(new JwtAuthFilter(userDetailsService, jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthFilter(userDetailsService, jwtTokenProvider, redisTemplate), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 

--- a/src/main/java/com/anipick/backend/user/controller/UserController.java
+++ b/src/main/java/com/anipick/backend/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.anipick.backend.token.dto.TokenResponse;
 import com.anipick.backend.user.dto.LoginRequest;
 import com.anipick.backend.user.dto.SignUpRequest;
 import com.anipick.backend.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,5 +25,11 @@ public class UserController {
     public ApiResponse<TokenResponse> login(@RequestBody LoginRequest request) {
         TokenResponse response = userService.doLogin(request);
         return ApiResponse.success(response);
+    }
+
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(HttpServletRequest request) {
+        userService.doLogout(request);
+        return ApiResponse.success();
     }
 }

--- a/src/main/java/com/anipick/backend/user/controller/UserController.java
+++ b/src/main/java/com/anipick/backend/user/controller/UserController.java
@@ -3,7 +3,6 @@ package com.anipick.backend.user.controller;
 import com.anipick.backend.common.dto.ApiResponse;
 import com.anipick.backend.token.dto.TokenResponse;
 import com.anipick.backend.user.dto.LoginRequest;
-import com.anipick.backend.user.domain.User;
 import com.anipick.backend.user.dto.SignUpRequest;
 import com.anipick.backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -16,9 +15,9 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ApiResponse<User> signUp(@RequestBody SignUpRequest request) {
-        User user = userService.signUp(request);
-        return ApiResponse.success(user);
+    public ApiResponse<Void> signUp(@RequestBody SignUpRequest request) {
+        userService.signUp(request);
+        return ApiResponse.success();
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/anipick/backend/user/domain/UserDefaults.java
+++ b/src/main/java/com/anipick/backend/user/domain/UserDefaults.java
@@ -8,4 +8,5 @@ public final class UserDefaults {
     public static final String DEFAULT_PROFILE_IMAGE_URL = "default.png";
     public static final Boolean DEFAULT_ADULT_YN = false;
     public static final Boolean DEFAULT_REVIEW_COMPLETED_YN = false;
+    public static final String DEFAULT_BLACKLIST_FORMAT = "blacklist:";
 }

--- a/src/main/java/com/anipick/backend/user/domain/UserDefaults.java
+++ b/src/main/java/com/anipick/backend/user/domain/UserDefaults.java
@@ -8,5 +8,5 @@ public final class UserDefaults {
     public static final String DEFAULT_PROFILE_IMAGE_URL = "default.png";
     public static final Boolean DEFAULT_ADULT_YN = false;
     public static final Boolean DEFAULT_REVIEW_COMPLETED_YN = false;
-    public static final String DEFAULT_BLACKLIST_FORMAT = "blacklist:";
+    public static final String DEFAULT_LOGOUT_LIST_FORMAT = "logout_list:";
 }

--- a/src/main/java/com/anipick/backend/user/service/UserService.java
+++ b/src/main/java/com/anipick/backend/user/service/UserService.java
@@ -26,7 +26,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final TokenService tokenService;
 
-    public User signUp(SignUpRequest request) {
+    public void signUp(SignUpRequest request) {
         String requestEmail = request.getEmail();
         String requestPassword = request.getPassword();
 
@@ -60,8 +60,6 @@ public class UserService {
                 .build();
 
         userMapper.insertUser(user);
-
-        return user;
     }
 
     private boolean checkDuplicateEmail(String email) {

--- a/src/main/java/com/anipick/backend/user/service/UserService.java
+++ b/src/main/java/com/anipick/backend/user/service/UserService.java
@@ -1,6 +1,6 @@
 package com.anipick.backend.user.service;
 
-import com.anipick.backend.common.dto.ApiResponse;
+import com.anipick.backend.common.auth.JwtTokenProvider;
 import com.anipick.backend.common.exception.CustomException;
 import com.anipick.backend.common.exception.ErrorCode;
 import com.anipick.backend.token.dto.TokenResponse;
@@ -11,8 +11,9 @@ import com.anipick.backend.user.domain.User;
 import com.anipick.backend.user.domain.UserDefaults;
 import com.anipick.backend.user.dto.SignUpRequest;
 import com.anipick.backend.user.mapper.UserMapper;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -20,11 +21,12 @@ import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class UserService {
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
     private final TokenService tokenService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
 
     public void signUp(SignUpRequest request) {
         String requestEmail = request.getEmail();
@@ -75,5 +77,13 @@ public class UserService {
         }
 
         return tokenService.generateAndSaveTokens(user.getEmail());
+    }
+
+    public void doLogout(HttpServletRequest request) {
+        String accessToken = jwtTokenProvider.resolveAccessToken(request);
+        jwtTokenProvider.validateToken(accessToken);
+        int accessTokenExpireTime = jwtTokenProvider.getAccessTokenExpiration();
+
+        redisTemplate.opsForValue().set(UserDefaults.DEFAULT_BLACKLIST_FORMAT + accessToken, "logout", accessTokenExpireTime);
     }
 }

--- a/src/main/java/com/anipick/backend/user/service/UserService.java
+++ b/src/main/java/com/anipick/backend/user/service/UserService.java
@@ -84,6 +84,6 @@ public class UserService {
         jwtTokenProvider.validateToken(accessToken);
         int accessTokenExpireTime = jwtTokenProvider.getAccessTokenExpiration();
 
-        redisTemplate.opsForValue().set(UserDefaults.DEFAULT_BLACKLIST_FORMAT + accessToken, "logout", accessTokenExpireTime);
+        redisTemplate.opsForValue().set(UserDefaults.DEFAULT_LOGOUT_LIST_FORMAT + accessToken, "logout", accessTokenExpireTime);
     }
 }

--- a/src/main/resources/mapper/user/UserQueryMapper.xml
+++ b/src/main/resources/mapper/user/UserQueryMapper.xml
@@ -5,15 +5,54 @@
 
 <mapper namespace="com.anipick.backend.user.mapper.UserMapper">
     <select id="findByUserId" resultType="com.anipick.backend.user.domain.User">
-        select * from User where user_id = #{userId}
+        select u.user_id as userId,
+               u.email as email,
+               u.password as password,
+               u.nickname as nickname,
+               u.profile_image_url as profileImageUrl,
+               u.login_format as loginFormat,
+               u.created_at as createAt,
+               u.updated_at as updatedAt,
+               u.deleted_at as deletedAt,
+               u.terms_and_conditions as termsAndConditions,
+               u.adult_yn as adultYn,
+               u.review_completed_yn as reviewCompletedYn
+        from User u
+        where user_id = #{userId}
     </select>
 
     <select id="findByEmail" resultType="com.anipick.backend.user.domain.User">
-        select * from User where email = #{email}
+        select u.user_id as userId,
+               u.email as email,
+               u.password as password,
+               u.nickname as nickname,
+               u.profile_image_url as profileImageUrl,
+               u.login_format as loginFormat,
+               u.created_at as createAt,
+               u.updated_at as updatedAt,
+               u.deleted_at as deletedAt,
+               u.terms_and_conditions as termsAndConditions,
+               u.adult_yn as adultYn,
+               u.review_completed_yn as reviewCompletedYn
+        from User u
+        where email = #{email}
     </select>
 
     <select id="findByNickname" resultType="com.anipick.backend.user.domain.User">
-        select * from User where nickname = #{nickname}
+        select u.user_id as userId,
+               u.email as email,
+               u.password as password,
+               u.nickname as nickname,
+               u.profile_image_url as profileImageUrl,
+               u.login_format as loginFormat,
+               u.created_at as createAt,
+               u.updated_at as updatedAt,
+               u.deleted_at as deletedAt,
+               u.terms_and_conditions as termsAndConditions,
+               u.adult_yn as adultYn,
+               u.review_completed_yn as reviewCompletedYn
+        from User u
+        where nickname = #{nickname}
     </select>
 
     <select id="existsByNickname" resultType="boolean">


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->
* AuthFilter에서 Exception 발생 시 인코딩이 제대로 되지 않는 버그를 수정했습니다.
* 회원가입 시 ApiResponse의 반환 타입을 void로 수정했습니다.
* User domain에서의 select 쿼리의 컬럼에 alias를 적용했습니다.
* 로그아웃 기능을 추가하였습니다.
---

**work-details**
* AuthFilter에서 Exception 발생 시 인코딩이 제대로 되지 않아 ??? ??? ???로 표시되어 charset-utf8로 인코딩 적용했습니다.
* select 쿼리에서 컬럼 필드가 user_id 등 snake_case로 되어있어 camelCase가 적용되도록 alias 적용했습니다.
* 로그아웃 시 redis에 블랙 리스트를 만든 후 accessToken을 담습니다.
* 블랙 리스트의 accessToken은 만료 시간(TTL)까지만 존재합니다. 
* 이후 인증이 필요한 API 호출 시 JWTAuthFilter의 유효성 검증에서 블랙 리스트에 accessToken이 존재한다면 401 error가 반환됩니다.
**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->
* 회원가입, 로그아웃 시 응답 값
![image](https://github.com/user-attachments/assets/a7a5cd4d-c5e6-42bc-9817-97046cda4ad9)
* AuthFilter Exception 발생 시 응답 값
![image](https://github.com/user-attachments/assets/8b22f6f2-f8e3-4b45-867c-ab69a68dd6bd)
* CustomUserDetails 적용 확인
![image](https://github.com/user-attachments/assets/46630e1e-c797-4ba7-a0ac-fc46cd44e07a)

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
