### PR TITLE
fix/리뷰 작성 시 애니 테이블 업데이트 반영

### DIFF
--- a/src/main/java/com/anipick/backend/anime/domain/Anime.java
+++ b/src/main/java/com/anipick/backend/anime/domain/Anime.java
@@ -1,0 +1,38 @@
+package com.anipick.backend.anime.domain;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Anime {
+	private Long animeId;
+	private String titleKor;
+	private String coverImageUrl;
+	private String bannerImageUrl;
+	private String descriptionKor;
+	private LocalDate startDate;
+	private LocalDate endDate;
+	// 애니리스트의 분기는 우리나라와 맞지 않아서 season_int 는 X
+	private Long seasonYear;
+	private Long episodeCount;
+	private Long duration;
+	private AnimeStatus status;
+	private Double averageScore;
+	private Long popularity;
+	private Boolean isAdult;
+	private AnimeFormat format;
+	private Long reviewCount;
+	// 다음 에피소드 방영일
+	private LocalDateTime nextAiringAt;
+	// 다음 에피소드 방영일까지 남은 시간
+	private String nextTimeUntilAiring;
+	// 다음 에피소드
+	private Long nextEpisode;
+}

--- a/src/main/java/com/anipick/backend/anime/domain/AnimeStatus.java
+++ b/src/main/java/com/anipick/backend/anime/domain/AnimeStatus.java
@@ -1,0 +1,10 @@
+package com.anipick.backend.anime.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AnimeStatus {
+	FINISHED, RELEASING, NOT_YET_RELEASED, CANCELLED, HIATUS
+}

--- a/src/main/java/com/anipick/backend/anime/mapper/AnimeMapper.java
+++ b/src/main/java/com/anipick/backend/anime/mapper/AnimeMapper.java
@@ -2,8 +2,10 @@ package com.anipick.backend.anime.mapper;
 
 import java.util.List;
 
+import com.anipick.backend.anime.domain.Anime;
 import com.anipick.backend.anime.dto.*;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface AnimeMapper {
@@ -16,4 +18,8 @@ public interface AnimeMapper {
 	List<ComingSoonItemPopularityDto> selectComingSoonPopularityAnimes(ComingSoonRequestDto comingSoonRequestDto);
 
 	List<ComingSoonItemBasicDto> selectComingSoonStartDateAnimes(ComingSoonRequestDto comingSoonRequestDto);
+
+	Anime selectAnimeByAnimeId(@Param("animeId") Long animeId);
+
+	void updateReviewCount(@Param("updateReviewCount") Long updateReviewCount, @Param("animeId") Long animeId);
 }

--- a/src/main/java/com/anipick/backend/review/controller/ReviewController.java
+++ b/src/main/java/com/anipick/backend/review/controller/ReviewController.java
@@ -3,7 +3,6 @@ package com.anipick.backend.review.controller;
 import com.anipick.backend.common.auth.dto.CustomUserDetails;
 import com.anipick.backend.common.dto.ApiResponse;
 import com.anipick.backend.review.dto.RecentReviewPageDto;
-import com.anipick.backend.review.dto.ReviewRatingRequest;
 import com.anipick.backend.review.dto.ReviewRequest;
 import com.anipick.backend.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +26,6 @@ public class ReviewController {
         RecentReviewPageDto page = reviewService.getRecentReviews(userId, lastId, size);
         return ApiResponse.success(page);
     }
-
 
     @PatchMapping("/{reviewId}/animes")
     public ApiResponse<Void> createAndUpdateReview(

--- a/src/main/resources/mapper/anime/AnimeCommandMapper.xml
+++ b/src/main/resources/mapper/anime/AnimeCommandMapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.anipick.backend.anime.mapper.AnimeMapper">
+    <update id="updateReviewCount">
+        UPDATE Anime
+        SET review_count = #{updateReviewCount}
+        WHERE anime_id = #{animeId}
+    </update>
+</mapper>

--- a/src/main/resources/mapper/anime/AnimeQueryMapper.xml
+++ b/src/main/resources/mapper/anime/AnimeQueryMapper.xml
@@ -117,4 +117,28 @@
                  a.anime_id
         LIMIT #{size}
     </select>
+
+    <select id="selectAnimeByAnimeId" resultType="com.anipick.backend.anime.domain.Anime">
+        SELECT a.anime_id AS animeId,
+               a.title_kor AS titleKor,
+               a.cover_image_url AS coverImageUrl,
+               a.banner_image_url AS bannerImageUrl,
+               a.description_kor AS descriptionKor,
+               a.start_date AS startDate,
+               a.end_date AS endDate,
+               a.season_year AS seasonYear,
+               a.episode_count AS episodeCount,
+               a.duration AS duration,
+               a.status AS status,
+               a.average_score AS averageScore,
+               a.popularity AS popularity,
+               a.is_adult AS isAdult,
+               a.format AS format,
+               a.review_count AS reviewCount,
+               a.next_airing_at AS nextAiringAt,
+               a.next_time_until_airing AS nextTimeUntilAiring,
+               a.next_episode AS nextEpisode
+        FROM Anime a
+        WHERE a.anime_id = #{animeId}
+    </select>
 </mapper>


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- [리뷰 작성](https://github.com/Anipick-Team/anipick-backend/pull/54)에서 Anime.reviewCount 컬럼을 따로 관리하지 않음
- 리뷰(Content 가 있는) 작성 시, 삭제 시에 따라 해당 컬럼 업데이트 처리
- 안 쓰이는 import 제거 및 코드 정렬

---

**work-details**

- 리뷰 작성, 삭제 시 비정규화된 컬럼(Anime.reviewCount)을 업데이트합니다.
- Anime 클래스는 현재 필요하지 않는 필드들이 존재합니다. 하지만 추후 확장성을 고려해 작성했습니다. (mapper도 같은 이유)

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test
