### PR TITLE
feat/소셜 로그인 카카오 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'com.google.api-client:google-api-client:2.7.2'
     implementation 'com.google.oauth-client:google-oauth-client-jetty:1.39.0'
     implementation 'com.google.http-client:google-http-client-jackson2:1.43.3'

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    google()
 }
 
 dependencies {
@@ -30,6 +31,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.google.api-client:google-api-client:2.7.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.39.0'
+    implementation 'com.google.http-client:google-http-client-jackson2:1.43.3'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/anipick/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/anipick/backend/common/config/SecurityConfig.java
@@ -15,11 +15,6 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -32,12 +27,11 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(
                         auth ->
-                                auth.requestMatchers("/api/users/**")
+                                auth.requestMatchers("/api/users/**", "/api/oauth/**")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated()
@@ -48,19 +42,6 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(new JwtAuthFilter(userDetailsService, jwtTokenProvider, redisTemplate), UsernamePasswordAuthenticationFilter.class)
                 .build();
-    }
-
-    @Bean
-    CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
-        configuration.setAllowedMethods(Arrays.asList("*"));
-        configuration.setAllowedHeaders(Arrays.asList("*"));
-        configuration.setAllowCredentials(true);
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
     }
 
     @Bean

--- a/src/main/java/com/anipick/backend/oauth/config/WebClientConfig.java
+++ b/src/main/java/com/anipick/backend/oauth/config/WebClientConfig.java
@@ -1,0 +1,20 @@
+package com.anipick.backend.oauth.config;
+
+import com.anipick.backend.oauth.domain.KakaoDefaults;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+                .baseUrl(KakaoDefaults.DEFAULT_WEBCLIENT_BASE_URL)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/com/anipick/backend/oauth/controller/OAuthController.java
+++ b/src/main/java/com/anipick/backend/oauth/controller/OAuthController.java
@@ -1,0 +1,21 @@
+package com.anipick.backend.oauth.controller;
+
+import com.anipick.backend.common.dto.ApiResponse;
+import com.anipick.backend.oauth.dto.SocialLoginRequest;
+import com.anipick.backend.oauth.service.OAuthService;
+import com.anipick.backend.token.dto.TokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/oauth")
+public class OAuthController {
+    private final OAuthService oAuthService;
+
+    @PostMapping("/{provider}/callback")
+    public ApiResponse<TokenResponse> socialLogin(@RequestBody SocialLoginRequest request, @PathVariable String provider) {
+        TokenResponse response = oAuthService.socialLogin(request, provider);
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/com/anipick/backend/oauth/controller/OAuthController.java
+++ b/src/main/java/com/anipick/backend/oauth/controller/OAuthController.java
@@ -1,6 +1,7 @@
 package com.anipick.backend.oauth.controller;
 
 import com.anipick.backend.common.dto.ApiResponse;
+import com.anipick.backend.oauth.domain.Provider;
 import com.anipick.backend.oauth.dto.SocialLoginRequest;
 import com.anipick.backend.oauth.service.OAuthService;
 import com.anipick.backend.token.dto.TokenResponse;
@@ -15,7 +16,8 @@ public class OAuthController {
 
     @PostMapping("/{provider}/callback")
     public ApiResponse<TokenResponse> socialLogin(@RequestBody SocialLoginRequest request, @PathVariable String provider) {
-        TokenResponse response = oAuthService.socialLogin(request, provider);
+        Provider oAuthProvider = Provider.valueOf(provider.toUpperCase());
+        TokenResponse response = oAuthService.socialLogin(request, oAuthProvider);
         return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/anipick/backend/oauth/domain/KakaoDefaults.java
+++ b/src/main/java/com/anipick/backend/oauth/domain/KakaoDefaults.java
@@ -1,0 +1,12 @@
+package com.anipick.backend.oauth.domain;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KakaoDefaults {
+    public static final String DEFAULT_WEBCLIENT_BASE_URL = "https://kapi.kakao.com";
+    public static final String DEFAULT_POST_URI = "/v2/user/me";
+    public static final String DEFAULT_ACCOUNT_ROOT_PATH = "kakao_account";
+    public static final String DEFAULT_EMAIL_PATH = "email";
+}

--- a/src/main/java/com/anipick/backend/oauth/domain/Platform.java
+++ b/src/main/java/com/anipick/backend/oauth/domain/Platform.java
@@ -1,0 +1,5 @@
+package com.anipick.backend.oauth.domain;
+
+public enum Platform {
+    ANDROID, IOS
+}

--- a/src/main/java/com/anipick/backend/oauth/domain/Provider.java
+++ b/src/main/java/com/anipick/backend/oauth/domain/Provider.java
@@ -1,0 +1,5 @@
+package com.anipick.backend.oauth.domain;
+
+public enum Provider {
+    GOOGLE, KAKAO, APPLE
+}

--- a/src/main/java/com/anipick/backend/oauth/dto/SocialLoginRequest.java
+++ b/src/main/java/com/anipick/backend/oauth/dto/SocialLoginRequest.java
@@ -1,0 +1,9 @@
+package com.anipick.backend.oauth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SocialLoginRequest {
+    private String platform;
+    private String code;
+}

--- a/src/main/java/com/anipick/backend/oauth/service/OAuthService.java
+++ b/src/main/java/com/anipick/backend/oauth/service/OAuthService.java
@@ -1,0 +1,79 @@
+package com.anipick.backend.oauth.service;
+
+import com.anipick.backend.common.exception.CustomException;
+import com.anipick.backend.common.exception.ErrorCode;
+import com.anipick.backend.oauth.dto.SocialLoginRequest;
+import com.anipick.backend.oauth.util.GoogleVerifierUtil;
+import com.anipick.backend.token.dto.TokenResponse;
+import com.anipick.backend.token.service.TokenService;
+import com.anipick.backend.user.domain.LoginFormat;
+import com.anipick.backend.user.domain.User;
+import com.anipick.backend.user.domain.UserDefaults;
+import com.anipick.backend.user.mapper.UserMapper;
+import com.anipick.backend.user.service.NicknameInitializer;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+    private final UserMapper userMapper;
+    private final TokenService tokenService;
+
+    public TokenResponse socialLogin(SocialLoginRequest request, String provider) {
+        String platform = request.getPlatform();
+        String idToken = request.getCode();
+
+        switch (provider) {
+            case "GOOGLE":
+                return googleLogin(platform, idToken);
+        }
+
+        return null;
+    }
+
+    private TokenResponse googleLogin(String platform, String idToken) {
+        try {
+            GoogleIdToken.Payload payload;
+            if(platform.equals("android")) {
+                payload = GoogleVerifierUtil.verifyAndroidGoogleToken(idToken);
+            } else if(platform.equals("ios")) {
+                payload = GoogleVerifierUtil.verifyIosGoogleToken(idToken);
+            } else {
+                throw new CustomException(ErrorCode.BAD_REQUEST);
+            }
+
+            String email = payload.getEmail();
+            if(checkExistsEmail(email)) {
+                return tokenService.generateAndSaveTokens(email);
+            } else {
+                String nickname = NicknameInitializer.generateUniqueNickname(userMapper::existsByNickname);
+                User user = User.builder()
+                        .email(email)
+                        .nickname(nickname)
+                        .loginFormat(LoginFormat.GOOGLE)
+                        .profileImageUrl(UserDefaults.DEFAULT_PROFILE_IMAGE_URL)
+                        .termsAndConditions(true)
+                        .adultYn(UserDefaults.DEFAULT_ADULT_YN)
+                        .reviewCompletedYn(UserDefaults.DEFAULT_REVIEW_COMPLETED_YN)
+                        .createdAt(LocalDateTime.now())
+                        .updatedAt(LocalDateTime.now())
+                        .build();
+
+                userMapper.insertUser(user);
+            }
+
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        return null;
+    }
+
+    private boolean checkExistsEmail(String email) {
+        return userMapper.findByEmail(email).isPresent();
+    }
+}

--- a/src/main/java/com/anipick/backend/oauth/service/OAuthService.java
+++ b/src/main/java/com/anipick/backend/oauth/service/OAuthService.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 public class OAuthService {
     private final UserMapper userMapper;
     private final TokenService tokenService;
+    private final GoogleVerifierUtil googleVerifierUtil;
 
     public TokenResponse socialLogin(SocialLoginRequest request, String provider) {
         String platform = request.getPlatform();
@@ -39,9 +40,9 @@ public class OAuthService {
         try {
             GoogleIdToken.Payload payload;
             if(platform.equals("android")) {
-                payload = GoogleVerifierUtil.verifyAndroidGoogleToken(idToken);
+                payload = googleVerifierUtil.verifyAndroidGoogleToken(idToken);
             } else if(platform.equals("ios")) {
-                payload = GoogleVerifierUtil.verifyIosGoogleToken(idToken);
+                payload = googleVerifierUtil.verifyIosGoogleToken(idToken);
             } else {
                 throw new CustomException(ErrorCode.BAD_REQUEST);
             }

--- a/src/main/java/com/anipick/backend/oauth/service/OAuthService.java
+++ b/src/main/java/com/anipick/backend/oauth/service/OAuthService.java
@@ -2,6 +2,7 @@ package com.anipick.backend.oauth.service;
 
 import com.anipick.backend.common.exception.CustomException;
 import com.anipick.backend.common.exception.ErrorCode;
+import com.anipick.backend.oauth.domain.KakaoDefaults;
 import com.anipick.backend.oauth.domain.Platform;
 import com.anipick.backend.oauth.domain.Provider;
 import com.anipick.backend.oauth.dto.SocialLoginRequest;
@@ -13,9 +14,12 @@ import com.anipick.backend.user.domain.User;
 import com.anipick.backend.user.domain.UserDefaults;
 import com.anipick.backend.user.mapper.UserMapper;
 import com.anipick.backend.user.service.NicknameInitializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.LocalDateTime;
 
@@ -25,15 +29,19 @@ public class OAuthService {
     private final UserMapper userMapper;
     private final TokenService tokenService;
     private final GoogleVerifierUtil googleVerifierUtil;
+    private final WebClient webClient;
 
     public TokenResponse socialLogin(SocialLoginRequest request, Provider provider) {
         String platform = request.getPlatform();
-        String idToken = request.getCode();
+        String code = request.getCode();
         Platform platformEnum = Platform.valueOf(platform.toUpperCase());
 
         switch (provider) {
             case GOOGLE:
-                return googleLogin(platformEnum, idToken);
+                return googleLogin(platformEnum, code);
+
+            case KAKAO:
+                return kakaoLogin(platformEnum, code);
         }
 
         return null;
@@ -51,29 +59,57 @@ public class OAuthService {
             }
 
             String email = payload.getEmail();
-            if(checkExistsEmail(email)) {
-                return tokenService.generateAndSaveTokens(email);
-            } else {
-                String nickname = NicknameInitializer.generateUniqueNickname(userMapper::existsByNickname);
-                User user = User.builder()
-                        .email(email)
-                        .nickname(nickname)
-                        .loginFormat(LoginFormat.GOOGLE)
-                        .profileImageUrl(UserDefaults.DEFAULT_PROFILE_IMAGE_URL)
-                        .termsAndConditions(true)
-                        .adultYn(UserDefaults.DEFAULT_ADULT_YN)
-                        .reviewCompletedYn(UserDefaults.DEFAULT_REVIEW_COMPLETED_YN)
-                        .createdAt(LocalDateTime.now())
-                        .updatedAt(LocalDateTime.now())
-                        .build();
-
-                userMapper.insertUser(user);
-
-                return tokenService.generateAndSaveTokens(email);
-            }
-
+            return signUpAndLogin(email, LoginFormat.GOOGLE);
         } catch (Exception e) {
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private TokenResponse kakaoLogin(Platform platform, String accessToken) {
+        try {
+            String response = webClient.post()
+                    .uri(KakaoDefaults.DEFAULT_POST_URI)
+                    .headers(headers -> headers.setBearerAuth(accessToken))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(response);
+
+            JsonNode account = root.path(KakaoDefaults.DEFAULT_ACCOUNT_ROOT_PATH);
+            String email = account.path(KakaoDefaults.DEFAULT_EMAIL_PATH).asText(null);
+
+            if(email == null || email.isEmpty()) {
+                throw new CustomException(ErrorCode.ACCOUNT_NOT_FOUND_BY_EMAIL);
+            }
+
+            return signUpAndLogin(email, LoginFormat.KAKAO);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private TokenResponse signUpAndLogin(String email, LoginFormat loginFormat) {
+        if(checkExistsEmail(email)) {
+            return tokenService.generateAndSaveTokens(email);
+        } else {
+            String nickname = NicknameInitializer.generateUniqueNickname(userMapper::existsByNickname);
+            User user = User.builder()
+                    .email(email)
+                    .nickname(nickname)
+                    .loginFormat(loginFormat)
+                    .profileImageUrl(UserDefaults.DEFAULT_PROFILE_IMAGE_URL)
+                    .termsAndConditions(true)
+                    .adultYn(UserDefaults.DEFAULT_ADULT_YN)
+                    .reviewCompletedYn(UserDefaults.DEFAULT_REVIEW_COMPLETED_YN)
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+
+            userMapper.insertUser(user);
+
+            return tokenService.generateAndSaveTokens(email);
         }
     }
 

--- a/src/main/java/com/anipick/backend/oauth/util/GoogleVerifierUtil.java
+++ b/src/main/java/com/anipick/backend/oauth/util/GoogleVerifierUtil.java
@@ -1,0 +1,44 @@
+package com.anipick.backend.oauth.util;
+
+import com.anipick.backend.common.exception.CustomException;
+import com.anipick.backend.common.exception.ErrorCode;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+public class GoogleVerifierUtil {
+    @Value("${app.oauth2.google.android-client-id}")
+    private static String androidClientId;
+
+    @Value("${app.oauth2.google.ios-client-id}")
+    private static String iosClientId;
+
+    public static GoogleIdToken.Payload verifyAndroidGoogleToken(String token) throws GeneralSecurityException, IOException {
+        return getPayload(token, androidClientId);
+    }
+
+    public static GoogleIdToken.Payload verifyIosGoogleToken(String token) throws GeneralSecurityException, IOException {
+        return getPayload(token, iosClientId);
+    }
+
+    private static GoogleIdToken.Payload getPayload(String token, String clientId) throws GeneralSecurityException, IOException {
+        GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), new GsonFactory())
+                .setAudience(Collections.singletonList(clientId))
+                .build();
+
+        GoogleIdToken googleIdToken = verifier.verify(token);
+        if(googleIdToken != null) {
+            return googleIdToken.getPayload();
+        } else {
+            throw new CustomException(ErrorCode.REQUESTED_TOKEN_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/anipick/backend/oauth/util/GoogleVerifierUtil.java
+++ b/src/main/java/com/anipick/backend/oauth/util/GoogleVerifierUtil.java
@@ -8,24 +8,26 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 
+@Component
 @RequiredArgsConstructor
 public class GoogleVerifierUtil {
     @Value("${app.oauth2.google.android-client-id}")
-    private static String androidClientId;
+    private String androidClientId;
 
     @Value("${app.oauth2.google.ios-client-id}")
-    private static String iosClientId;
+    private String iosClientId;
 
-    public static GoogleIdToken.Payload verifyAndroidGoogleToken(String token) throws GeneralSecurityException, IOException {
+    public GoogleIdToken.Payload verifyAndroidGoogleToken(String token) throws GeneralSecurityException, IOException {
         return getPayload(token, androidClientId);
     }
 
-    public static GoogleIdToken.Payload verifyIosGoogleToken(String token) throws GeneralSecurityException, IOException {
+    public GoogleIdToken.Payload verifyIosGoogleToken(String token) throws GeneralSecurityException, IOException {
         return getPayload(token, iosClientId);
     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,3 +26,9 @@ jwt:
   
 anime:
   default-cover-url: ${ANIME_DEFAULT_COVER_URL}
+
+app:
+  oauth2:
+    google:
+      android-client-id: ${ANDROID_CLIENT_ID}
+      ios-client-id: ${IOS_CLIENT_ID}


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->
* 카카오 소셜 로그인 기능을 추가하였습니다.

---

**work-details**
1. webClient 설정을 하기 위해 webflux 의존성을 추가하였습니다.
2. 회원가입 -> 로그인 / 로그인 공통 로직을 분리하였습니다.
3. Kakao 관련하여 상수 관리를 위해 class를 추가하였습니다.
4. Kakao 로그인의 경우 Google 로그인과 달리 client_id를 따로 관리할 필요가 없습니다. client_id, secret_key 모두 앱 개발자가 관리합니다.

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->
* Android 카카오 로그인 성공
![image](https://github.com/user-attachments/assets/1be550ad-71c7-4959-b5d9-edf6a3b5bd55)

* iOS 카카오 로그인 성공
![image](https://github.com/user-attachments/assets/c2f4b501-3ac6-4869-8f25-4c80010941a2)


### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test
