### PR TITLE
fix/오류 발생 시 http status code 함께 리턴

### DIFF
--- a/src/main/java/com/anipick/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/anipick/backend/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.anipick.backend.common.exception;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.anipick.backend.common.dto.ApiResponse;
@@ -10,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 public class GlobalExceptionHandler {
 
 	// CustomException


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 기존에는 서버 내의 오류가 나와도 `200 OK` 코드(HttpStatusCode)를 리턴했습니다. 응답 결과에는 커스텀 error code를 리턴합니다.
- GlobalExceptionHandler에서 HttpStatusCode를 리턴할 때 `500` 코드를 리턴하도록 변경합니다.

---

**work-details**

- 오류가 나타날 때 상태코드 HttpStatusCode 500 리턴

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

- 로그인 실패 시 
![image](https://github.com/user-attachments/assets/d57c2226-63a9-40c5-b75f-a4a65f6c9741)



### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
