### PR TITLE
feat/애니 상세 (작품) - 애니 정보 조회

### DIFF
--- a/src/main/java/com/anipick/backend/anime/controller/AnimeController.java
+++ b/src/main/java/com/anipick/backend/anime/controller/AnimeController.java
@@ -1,5 +1,6 @@
 package com.anipick.backend.anime.controller;
 
+import com.anipick.backend.anime.dto.AnimeDetailInfoResultDto;
 import com.anipick.backend.anime.dto.ComingSoonPageDto;
 import com.anipick.backend.anime.dto.UpcomingSeasonResultDto;
 import com.anipick.backend.anime.service.AnimeService;
@@ -7,10 +8,7 @@ import com.anipick.backend.common.auth.dto.CustomUserDetails;
 import com.anipick.backend.common.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/animes")
@@ -39,6 +37,16 @@ public class AnimeController {
 		ComingSoonPageDto result = animeService.getComingSoonAnimes(
 				sort, lastId, size, includeAdult, lastValue
 		);
+		return ApiResponse.success(result);
+	}
+
+	@GetMapping("/{animeId}/detail/info")
+	public ApiResponse<AnimeDetailInfoResultDto> getAnimeInfoDetail(
+			@PathVariable(value = "animeId") Long animeId,
+			@AuthenticationPrincipal CustomUserDetails user
+	) {
+		Long userId = user.getUserId();
+		AnimeDetailInfoResultDto result = animeService.getAnimeInfoDetail(animeId, userId);
 		return ApiResponse.success(result);
 	}
 }

--- a/src/main/java/com/anipick/backend/anime/domain/AnimeStatus.java
+++ b/src/main/java/com/anipick/backend/anime/domain/AnimeStatus.java
@@ -9,21 +9,23 @@ public enum AnimeStatus {
 	/**
 	 * 완료되어 출시되지 않는 상태
 	 */
-	FINISHED,
+	FINISHED("방영 종료"),
 	/**
 	 * 현재 출시 중인 상태
 	 */
-	RELEASING,
+	RELEASING("방영 중"),
 	/**
 	 * 추후 공개 예정인 상태
 	 */
-	NOT_YET_RELEASED,
+	NOT_YET_RELEASED("방영 예정"),
 	/**
 	 * 작업이 완료되기 전에 끝난 상태
 	 */
-	CANCELLED,
+	CANCELLED("방영 종료"),
 	/**
 	 * 현재 출시가 일시 중단되었으며 추후 재개될 상태
 	 */
-	HIATUS
+	HIATUS("일시 중단");
+
+	private final String statusName;
 }

--- a/src/main/java/com/anipick/backend/anime/dto/AnimeDetailInfoItemDto.java
+++ b/src/main/java/com/anipick/backend/anime/dto/AnimeDetailInfoItemDto.java
@@ -1,0 +1,25 @@
+package com.anipick.backend.anime.dto;
+
+import com.anipick.backend.anime.domain.AnimeStatus;
+import com.anipick.backend.user.domain.UserWatchStatus;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class AnimeDetailInfoItemDto {
+    private Long animeId;
+    private String title;
+    private String coverImageUrl;
+    private String bannerImageUrl;
+    private String description;
+    private String averageRating;
+    private Boolean isLiked;
+    private UserWatchStatus watchStatus;
+    private String type;
+    private int reviewCount;
+    private Long episode;
+    private LocalDate startDate;
+    private AnimeStatus status;
+    private String age;
+}

--- a/src/main/java/com/anipick/backend/anime/dto/AnimeDetailInfoResultDto.java
+++ b/src/main/java/com/anipick/backend/anime/dto/AnimeDetailInfoResultDto.java
@@ -1,0 +1,33 @@
+package com.anipick.backend.anime.dto;
+
+import com.anipick.backend.search.dto.StudioItemDto;
+import com.anipick.backend.user.domain.UserWatchStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AnimeDetailInfoResultDto {
+    private Long animeId;
+    private String title;
+    private String coverImageUrl;
+    private String bannerImageUrl;
+    private String description;
+    private String averageRating;
+    private Boolean isLiked;
+    private UserWatchStatus watchStatus;
+    private String type;
+    private int reviewCount;
+    private List<GenreDto> genres;
+    private Long episode;
+    private String airDate;
+    private String status;
+    private String age;
+    private List<StudioItemDto> studios;
+}

--- a/src/main/java/com/anipick/backend/anime/mapper/AnimeMapper.java
+++ b/src/main/java/com/anipick/backend/anime/mapper/AnimeMapper.java
@@ -24,4 +24,9 @@ public interface AnimeMapper {
 	void updatePlusReviewCount(@Param("animeId") Long animeId);
 
 	void updateMinusReviewCount(@Param("animeId") Long animeId);
+
+	AnimeDetailInfoItemDto selectAnimeInfoDetail(
+			@Param(value = "animeId") Long animeId,
+			@Param(value = "userId") Long userId
+	);
 }

--- a/src/main/java/com/anipick/backend/anime/mapper/GenreMapper.java
+++ b/src/main/java/com/anipick/backend/anime/mapper/GenreMapper.java
@@ -1,0 +1,12 @@
+package com.anipick.backend.anime.mapper;
+
+import com.anipick.backend.anime.dto.GenreDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface GenreMapper {
+    List<GenreDto> selectGenresByAnimeId(@Param(value = "animeId") Long animeId);
+}

--- a/src/main/java/com/anipick/backend/anime/mapper/StudioMapper.java
+++ b/src/main/java/com/anipick/backend/anime/mapper/StudioMapper.java
@@ -1,0 +1,12 @@
+package com.anipick.backend.anime.mapper;
+
+import com.anipick.backend.search.dto.StudioItemDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface StudioMapper {
+    List<StudioItemDto> selectStudiosByAnimeId(@Param(value = "animeId") Long animeId);
+}

--- a/src/main/java/com/anipick/backend/anime/service/AnimeService.java
+++ b/src/main/java/com/anipick/backend/anime/service/AnimeService.java
@@ -6,13 +6,18 @@ import com.anipick.backend.anime.domain.Season;
 import com.anipick.backend.anime.domain.SeasonConverter;
 import com.anipick.backend.anime.mapper.AnimeMapper;
 
+import com.anipick.backend.anime.mapper.GenreMapper;
+import com.anipick.backend.anime.mapper.StudioMapper;
+import com.anipick.backend.anime.util.FormatConvert;
 import com.anipick.backend.common.domain.SortOption;
 import com.anipick.backend.common.dto.CursorDto;
+import com.anipick.backend.search.dto.StudioItemDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -24,6 +29,8 @@ import java.util.stream.Collectors;
 @Slf4j
 public class AnimeService {
 	private final AnimeMapper mapper;
+	private final GenreMapper genreMapper;
+	private final StudioMapper studioMapper;
 	@Value("${anime.default-cover-url}")
 	private String defaultCoverUrl;
 
@@ -177,5 +184,50 @@ public class AnimeService {
 		}
 		CursorDto cursor = CursorDto.of(sort, nextId, nextValue);
 		return ComingSoonPageDto.of(totalCount, cursor, items);
+	}
+
+	@Transactional(readOnly = true)
+	public AnimeDetailInfoResultDto getAnimeInfoDetail(Long animeId, Long userId) {
+		AnimeDetailInfoItemDto animeDetailInfoItemDto = mapper.selectAnimeInfoDetail(animeId, userId);
+
+		String airDate;
+		if (animeDetailInfoItemDto.getStartDate() == null) {
+			airDate = "미정";
+		} else {
+			LocalDate startDate = animeDetailInfoItemDto.getStartDate();
+			Season season = Season.containsSeason(startDate);
+			airDate = animeDetailInfoItemDto.getStartDate().getYear() + "년 " + season.getName();
+		}
+
+		String type;
+		if (animeDetailInfoItemDto.getType() != null) {
+			String dtoType = animeDetailInfoItemDto.getType();
+            type = FormatConvert.toClientType(dtoType);
+		} else {
+			type = null;
+		}
+
+		List<GenreDto> genres = genreMapper.selectGenresByAnimeId(animeId);
+
+		List<StudioItemDto> studios = studioMapper.selectStudiosByAnimeId(animeId);
+
+		return AnimeDetailInfoResultDto.builder()
+				.animeId(animeDetailInfoItemDto.getAnimeId())
+				.title(animeDetailInfoItemDto.getTitle())
+				.coverImageUrl(animeDetailInfoItemDto.getCoverImageUrl())
+				.bannerImageUrl(animeDetailInfoItemDto.getBannerImageUrl())
+				.description(animeDetailInfoItemDto.getDescription())
+				.averageRating(animeDetailInfoItemDto.getAverageRating())
+				.isLiked(animeDetailInfoItemDto.getIsLiked())
+				.watchStatus(animeDetailInfoItemDto.getWatchStatus())
+				.type(type)
+				.reviewCount(animeDetailInfoItemDto.getReviewCount())
+				.genres(genres)
+				.episode(animeDetailInfoItemDto.getEpisode())
+				.airDate(airDate)
+				.status(animeDetailInfoItemDto.getStatus().getStatusName())
+				.age(animeDetailInfoItemDto.getAge())
+				.studios(studios)
+				.build();
 	}
 }

--- a/src/main/java/com/anipick/backend/anime/util/FormatConvert.java
+++ b/src/main/java/com/anipick/backend/anime/util/FormatConvert.java
@@ -5,13 +5,24 @@ import java.util.List;
 import java.util.Map;
 
 import com.anipick.backend.anime.domain.AnimeFormat;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class FormatConvert {
 	private static final Map<String, List<AnimeFormat>> MAP = Map.of(
 		"TVA", List.of(AnimeFormat.TV, AnimeFormat.TV_SHORT, AnimeFormat.ONA),
 		"OVA", List.of(AnimeFormat.OVA, AnimeFormat.SPECIAL),
 		"극장판", List.of(AnimeFormat.MOVIE)
 	);
+
+    private static final Map<AnimeFormat, String> REVERSE_CLIENT_MAP = Map.of(
+            AnimeFormat.TV, "TVA",
+            AnimeFormat.TV_SHORT, "TVA",
+            AnimeFormat.ONA, "TVA",
+            AnimeFormat.OVA, "OVA",
+            AnimeFormat.SPECIAL, "OVA",
+            AnimeFormat.MOVIE, "극장판"
+    );
 
 	public static List<String> toConvert(String clientFromType) {
 		if (clientFromType == null) {
@@ -22,4 +33,17 @@ public class FormatConvert {
 			.map(Enum::name)
 			.toList();
 	}
+
+    public static String toClientType(String formatName) {
+        if (formatName == null) {
+            return null;
+        }
+        try {
+            AnimeFormat format = AnimeFormat.valueOf(formatName);
+            return REVERSE_CLIENT_MAP.get(format);
+        } catch (IllegalArgumentException e) {
+			log.error("Anime toClientType method error format : {}, return 기타", formatName);
+            return "기타";
+        }
+    }
 }

--- a/src/main/java/com/anipick/backend/user/domain/UserWatchStatus.java
+++ b/src/main/java/com/anipick/backend/user/domain/UserWatchStatus.java
@@ -1,0 +1,19 @@
+package com.anipick.backend.user.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum UserWatchStatus {
+    /**
+     * 볼 예정
+     */
+    WATCHLIST,
+    /**
+     * 보는 중
+     */
+    WATCHING,
+    /**
+     * 다 본 애니
+     */
+    FINISHED
+}

--- a/src/main/resources/mapper/anime/AnimeQueryMapper.xml
+++ b/src/main/resources/mapper/anime/AnimeQueryMapper.xml
@@ -141,4 +141,30 @@
         FROM Anime a
         WHERE a.anime_id = #{animeId}
     </select>
+
+    <select id="selectAnimeInfoDetail" resultType="com.anipick.backend.anime.dto.AnimeDetailInfoItemDto">
+        SELECT a.anime_id AS animeId,
+               a.title_kor AS title,
+               a.cover_image_url AS coverImageUrl,
+               a.banner_image_url AS bannerImageUrl,
+               a.description_kor AS description,
+               a.review_average_score AS averageRating,
+               IF(ual.user_id IS NULL, FALSE, TRUE) AS isLiked,
+               us.status AS watchStatus,
+               a.format AS type,
+               a.review_count AS reviewCount,
+               a.episode_count AS episode,
+               a.start_date AS startDate,
+               a.status AS status,
+               a.age AS age
+        FROM anime a
+                 LEFT JOIN useranimelike ual
+                           ON a.anime_id = ual.anime_id
+                               AND ual.user_id = #{userId}
+                 LEFT JOIN useranimestatus us
+                           ON a.anime_id = us.anime_id
+                               AND us.user_id = #{userId}
+        WHERE a.anime_id = #{animeId}
+
+    </select>
 </mapper>

--- a/src/main/resources/mapper/anime/GenreQueryMapper.xml
+++ b/src/main/resources/mapper/anime/GenreQueryMapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.anipick.backend.anime.mapper.GenreMapper">
+    <select id="selectGenresByAnimeId" resultType="com.anipick.backend.anime.dto.GenreDto">
+        SELECT g.genre_id AS id,
+               g.genre_kor AS name
+        FROM genres g
+                 JOIN animegenres ag
+                      ON ag.genre_id = g.genre_id
+        WHERE anime_id = #{animeId}
+    </select>
+</mapper>

--- a/src/main/resources/mapper/anime/StudioQueryMapper.xml
+++ b/src/main/resources/mapper/anime/StudioQueryMapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.anipick.backend.anime.mapper.StudioMapper">
+    <select id="selectStudiosByAnimeId" resultType="com.anipick.backend.search.dto.StudioItemDto">
+        SELECT s.studio_id AS studioId,
+               s.name_kor AS name
+        FROM studio s
+                 JOIN animestudio a
+                      ON s.studio_id = a.studio_id
+        WHERE a.anime_id = #{animeId}
+    </select>
+</mapper>

--- a/src/test/java/com/anipick/backend/anime/util/FormatConvertTest.java
+++ b/src/test/java/com/anipick/backend/anime/util/FormatConvertTest.java
@@ -1,0 +1,37 @@
+package com.anipick.backend.anime.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FormatConvertTest {
+    @Test
+    @DisplayName("TV 입력 시 TVA 반환")
+    void tvReturnsTva() {
+        assertEquals("TVA", FormatConvert.toClientType("TV"));
+    }
+
+    @Test
+    @DisplayName("ONA 입력 시 TVA 반환")
+    void onaReturnsTva() {
+        assertEquals("TVA", FormatConvert.toClientType("ONA"));
+    }
+
+    @Test
+    @DisplayName("OVA 입력 시 OVA 반환")
+    void ovaReturnsOva() {
+        assertEquals("OVA", FormatConvert.toClientType("OVA"));
+    }
+
+    @Test
+    @DisplayName("MOVIE 입력 시 극장판 반환")
+    void movieReturns_movie() {
+        assertEquals("극장판", FormatConvert.toClientType("MOVIE"));
+    }
+
+    @Test
+    @DisplayName("지정된 값 외의 입력 시 기타 반환")
+    void unknownReturns_unknown() {
+        assertEquals("기타", FormatConvert.toClientType("X"));
+    }
+}


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->


---

**work-details**

- 애니 상세 (작품) 애니 정보 조회
- `FormatConvert` 클래스에서 기존에는 client로부터 `TVA`, `OVA`, `극장판`을 받으면 변환 후 내부에서 알맞은 Anime.format 을 찾았습니다.
  - 역으로 변환하는 로직이 없어, `toClientType` 메서드를 추가했습니다. null 처리와 알 수 없는 타입 (기획된 타입 외의 것)이 들어올 경우엔 `기타`로 처리했습니다. 혹시나 이 부분에 대해서 더 좋은 방안이 있다면 말씀해주시면 감사하겠습니다.

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test
