### PR TITLE
fix/리뷰 수정 API 엔드포인트 및 로직 수정 (review_id -> anime_id)

### DIFF
--- a/src/main/java/com/anipick/backend/review/controller/ReviewController.java
+++ b/src/main/java/com/anipick/backend/review/controller/ReviewController.java
@@ -27,14 +27,14 @@ public class ReviewController {
         return ApiResponse.success(page);
     }
 
-    @PatchMapping("/{reviewId}/animes")
+    @PatchMapping("/{animeId}/animes")
     public ApiResponse<Void> createAndUpdateReview(
-        @PathVariable(name = "reviewId") Long reviewId,
+        @PathVariable(name = "animeId") Long animeId,
         @RequestBody ReviewRequest request,
         @AuthenticationPrincipal CustomUserDetails user
     ) {
         Long userId = user.getUserId();
-        reviewService.createAndUpdateReview(reviewId, request, userId);
+        reviewService.createAndUpdateReview(animeId, request, userId);
         return ApiResponse.success();
     }
 

--- a/src/main/java/com/anipick/backend/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/anipick/backend/review/mapper/ReviewMapper.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 @Mapper
 public interface ReviewMapper {
 
-    Optional<Review> findByReviewId(@Param("reviewId") Long reviewId, @Param("userId") Long userId);
+    Optional<Review> findByReviewId(@Param("animeId") Long animeId, @Param("userId") Long userId);
 
 
     void updateReview(

--- a/src/main/java/com/anipick/backend/review/service/ReviewService.java
+++ b/src/main/java/com/anipick/backend/review/service/ReviewService.java
@@ -73,17 +73,16 @@ public class ReviewService {
 
 
     @Transactional
-    public void createAndUpdateReview(Long reviewId, ReviewRequest request, Long userId) {
-        Review review = reviewMapper.findByReviewId(reviewId, userId)
+    public void createAndUpdateReview(Long animeId, ReviewRequest request, Long userId) {
+        Review review = reviewMapper.findByReviewId(animeId, userId)
             .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
         if (request.getContent() == null || request.getContent().isBlank()) {
             throw new CustomException(ErrorCode.REVIEW_CONTENT_NOT_PROVIDED);
         }
         if (review.getContent() == null) {
-            Long animeId = review.getAnimeId();
             animeMapper.updatePlusReviewCount(animeId);
         }
-
+        Long reviewId = review.getReviewId();
         reviewMapper.updateReview(reviewId, userId, request);
     }
 

--- a/src/main/resources/mapper/review/ReviewQueryMapper.xml
+++ b/src/main/resources/mapper/review/ReviewQueryMapper.xml
@@ -16,7 +16,7 @@
                r.deleted_at AS deletedAt,
                r.isReported AS isReported
         FROM Review r
-        WHERE r.review_id = #{reviewId}
+        WHERE r.anime_id = #{animeId}
           AND r.user_id = #{userId}
     </select>
 </mapper>


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 엔드포인트를 `reviewId`로 할 경우, 프론트에서 `reviewId`를 알 수 있는 방법이 없음.
- `animeId`값은 알고 있기 때문에 엔드포인트를 `animeId`로 변경
- 서비스 로직도 `animeId` 사용

---

**work-details**

- 리뷰 수정 엔드포인트 및 로직 수정 (review_id -> anime_id)

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
