### PR TITLE
feat/애니 평가의 조회 애니 (탐색 및 검색)

### DIFF
--- a/src/main/java/com/anipick/backend/anime/mapper/MetaDataMapper.java
+++ b/src/main/java/com/anipick/backend/anime/mapper/MetaDataMapper.java
@@ -2,10 +2,13 @@ package com.anipick.backend.anime.mapper;
 
 import com.anipick.backend.anime.dto.GenreDto;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
 @Mapper
 public interface MetaDataMapper {
     List<GenreDto> selectAllGenres();
+
+    String selectGenresById(@Param(value = "genresId") Long genres);
 }

--- a/src/main/java/com/anipick/backend/explore/controller/SignUpAnimeController.java
+++ b/src/main/java/com/anipick/backend/explore/controller/SignUpAnimeController.java
@@ -1,0 +1,36 @@
+package com.anipick.backend.explore.controller;
+
+import com.anipick.backend.common.dto.ApiResponse;
+import com.anipick.backend.common.exception.ErrorCode;
+import com.anipick.backend.explore.dto.UserSignUpAnimePageDto;
+import com.anipick.backend.explore.service.UserSignUpAnimeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class SignUpAnimeController {
+
+    private final UserSignUpAnimeService userSignUpAnimeService;
+
+    @GetMapping("/explore-search")
+    public ApiResponse<UserSignUpAnimePageDto> getSignUpAnimeExploreSearch(
+            @RequestParam(value = "query", required = false) String query,
+            @RequestParam(value = "year", required = false) Integer year,
+            @RequestParam(value = "season", required = false) Integer season,
+            @RequestParam(value = "genres", required = false) Long genres,
+            @RequestParam(value = "lastId", required = false) Long lastId,
+            @RequestParam(value = "size", defaultValue = "10") int size
+    ) {
+        if (year == null && season != null) {
+			return ApiResponse.error(ErrorCode.EMPTY_YEAR);
+		}
+        UserSignUpAnimePageDto result =
+                userSignUpAnimeService.getAnimeExploreSearch(query, year, season, genres, lastId, size);
+        return ApiResponse.success(result);
+    }
+}

--- a/src/main/java/com/anipick/backend/explore/dto/AnimeIdGenreDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/AnimeIdGenreDto.java
@@ -1,0 +1,9 @@
+package com.anipick.backend.explore.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AnimeIdGenreDto {
+    private Long animeId;
+    private String genre;
+}

--- a/src/main/java/com/anipick/backend/explore/dto/SignUpAnimeExploreSearchRequestDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/SignUpAnimeExploreSearchRequestDto.java
@@ -1,0 +1,49 @@
+package com.anipick.backend.explore.dto;
+
+import com.anipick.backend.anime.domain.RangeDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class SignUpAnimeExploreSearchRequestDto {
+    private String query;
+    private String startDate;
+    private String endDate;
+    private Long genres;
+    private Long lastId;
+    private int size;
+
+    public static SignUpAnimeExploreSearchRequestDto of(
+            RangeDate rangeDate,
+            String query,
+            Long genres,
+            Long lastId,
+            int size
+    ) {
+        return new SignUpAnimeExploreSearchRequestDto(
+                query,
+                rangeDate.getStartDate(),
+                rangeDate.getEndDate(),
+                genres,
+                lastId,
+                size
+        );
+    }
+
+    public static SignUpAnimeExploreSearchRequestDto dateNullOf(
+            String query,
+            Long genres,
+            Long lastId,
+            int size
+    ) {
+        return new SignUpAnimeExploreSearchRequestDto(
+                query,
+                null,
+                null,
+                genres,
+                lastId,
+                size
+        );
+    }
+}

--- a/src/main/java/com/anipick/backend/explore/dto/SignUpAnimeItemDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/SignUpAnimeItemDto.java
@@ -1,0 +1,15 @@
+package com.anipick.backend.explore.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class SignUpAnimeItemDto {
+    private Long animeId;
+    private String title;
+    private String coverImageUrl;
+    private List<String> genres;
+}

--- a/src/main/java/com/anipick/backend/explore/dto/SignUpPopularAnimeItemDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/SignUpPopularAnimeItemDto.java
@@ -1,0 +1,16 @@
+package com.anipick.backend.explore.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class SignUpPopularAnimeItemDto  {
+    private Long animeId;
+    private Long popularId;
+    private String title;
+    private String coverImageUrl;
+    private List<String> genres;
+}

--- a/src/main/java/com/anipick/backend/explore/dto/UserSignUpAnimePageDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/UserSignUpAnimePageDto.java
@@ -1,0 +1,15 @@
+package com.anipick.backend.explore.dto;
+
+import com.anipick.backend.common.dto.CursorDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class UserSignUpAnimePageDto {
+    private Long count;
+    private CursorDto cursor;
+    private List<SignUpAnimeItemDto> animes;
+}

--- a/src/main/java/com/anipick/backend/explore/mapper/UserSignUpAnimeMapper.java
+++ b/src/main/java/com/anipick/backend/explore/mapper/UserSignUpAnimeMapper.java
@@ -1,0 +1,18 @@
+package com.anipick.backend.explore.mapper;
+
+import com.anipick.backend.explore.dto.AnimeIdGenreDto;
+import com.anipick.backend.explore.dto.SignUpAnimeExploreSearchRequestDto;
+import com.anipick.backend.explore.dto.SignUpPopularAnimeItemDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface UserSignUpAnimeMapper {
+    long countExploredAndSearch(SignUpAnimeExploreSearchRequestDto dto);
+
+    List<SignUpPopularAnimeItemDto> selectAnimeExploredAndSearch(SignUpAnimeExploreSearchRequestDto dto);
+
+    List<AnimeIdGenreDto> selectGenresByAnimeIds(@Param(value = "animeIds") List<Long> animeIds);
+}

--- a/src/main/java/com/anipick/backend/explore/service/UserSignUpAnimeService.java
+++ b/src/main/java/com/anipick/backend/explore/service/UserSignUpAnimeService.java
@@ -1,0 +1,151 @@
+package com.anipick.backend.explore.service;
+
+import com.anipick.backend.anime.domain.RangeDate;
+import com.anipick.backend.anime.domain.SeasonConverter;
+import com.anipick.backend.anime.mapper.MetaDataMapper;
+import com.anipick.backend.common.dto.CursorDto;
+import com.anipick.backend.explore.dto.*;
+import com.anipick.backend.explore.mapper.UserSignUpAnimeMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserSignUpAnimeService {
+
+    private final UserSignUpAnimeMapper userSignUpAnimeMapper;
+    private final MetaDataMapper metaDataMapper;
+
+    public UserSignUpAnimePageDto getAnimeExploreSearch(
+            String query,
+            Integer year,
+            Integer season,
+            Long genres,
+            Long lastId,
+            int size
+    ) {
+        log.debug("Anime explore search log : 년도={}, 분기={}, 장르 ID={}, 마지막 ID={}, 사이즈={}",
+                year, season, genres, lastId, size
+        );
+        String genresName;
+        if (genres != null) {
+            genresName = metaDataMapper.selectGenresById(genres);
+        } else {
+            genresName = null;
+        }
+
+        SignUpAnimeExploreSearchRequestDto requestDto =
+                makeExploreSearchRequestDto(query, year, season, genres, lastId, size);
+
+        long totalCount = userSignUpAnimeMapper.countExploredAndSearch(requestDto);
+
+
+        List<SignUpPopularAnimeItemDto> items = userSignUpAnimeMapper.
+                selectAnimeExploredAndSearch(requestDto);
+
+        List<SignUpAnimeItemDto> result = new ArrayList<>();
+
+        if (!items.isEmpty()) {
+            List<Long> animeIds = items.stream()
+                    .map(SignUpPopularAnimeItemDto::getAnimeId)
+                    .toList();
+
+            List<AnimeIdGenreDto> genreItems = userSignUpAnimeMapper.selectGenresByAnimeIds(animeIds);
+
+            Map<Long, List<String>> genreMap = new HashMap<>();
+
+            for (AnimeIdGenreDto dto : genreItems) {
+                Long animeId = dto.getAnimeId();
+                String genre = dto.getGenre();
+
+                if (!genreMap.containsKey(animeId)) {
+                    genreMap.put(animeId, new ArrayList<>());
+                }
+
+                genreMap.get(animeId).add(genre);
+            }
+
+            items.forEach(item ->
+                    item.setGenres(genreMap.getOrDefault(item.getAnimeId(), List.of()))
+            );
+        } else {
+            return UserSignUpAnimePageDto.of(totalCount, CursorDto.of(null), result);
+        }
+
+        result = items.stream()
+                .map(dto -> {
+                    List<String> genreList = new ArrayList<>();
+                    // 들어있는 장르가 null이 아니면서 3개 이상일 경우
+                    if (dto.getGenres() != null) {
+                        genreList.addAll(dto.getGenres());
+                    }
+
+                    if (genreList.size() >= 3) {
+                        List<String> genreTop3 = new ArrayList<>();
+                        genreTop3.add(genreList.get(0));
+                        genreTop3.add(genreList.get(1));
+                        genreTop3.add(genreList.get(2));
+
+                        if (genres != null && !genreTop3.contains(genresName)) {
+                            genreTop3.set(2, genresName);
+                        }
+                        genreList = genreTop3;
+                    }
+                    return SignUpAnimeItemDto.of(
+                            dto.getAnimeId(),
+                            dto.getTitle(),
+                            dto.getCoverImageUrl(),
+                            genreList
+                    );
+                })
+                .toList();
+
+        Long nextId;
+        if (items.isEmpty()) {
+            nextId = null;
+        } else {
+            nextId = items.getLast().getPopularId();
+        }
+
+        CursorDto cursor = CursorDto.of(nextId);
+
+        return UserSignUpAnimePageDto.of(totalCount, cursor, result);
+    }
+
+    private static SignUpAnimeExploreSearchRequestDto makeExploreSearchRequestDto(
+            String query, Integer year, Integer season, Long genres, Long lastId, Integer size
+    ) {
+        if (year != null && season != null) {
+            RangeDate dateRange = SeasonConverter.getRangDate(year, season);
+            return SignUpAnimeExploreSearchRequestDto.of(
+                    dateRange,
+                    query,
+                    genres,
+                    lastId,
+                    size
+            );
+        } else if (year != null) {
+            RangeDate dateRange = SeasonConverter.getYearRangDate(year);
+            return SignUpAnimeExploreSearchRequestDto.of(
+                    dateRange,
+                    query,
+                    genres,
+                    lastId,
+                    size
+            );
+        }
+        return SignUpAnimeExploreSearchRequestDto.dateNullOf(
+                query,
+                genres,
+                lastId,
+                size
+        );
+    };
+}

--- a/src/main/java/com/anipick/backend/explore/service/UserSignUpAnimeService.java
+++ b/src/main/java/com/anipick/backend/explore/service/UserSignUpAnimeService.java
@@ -83,21 +83,7 @@ public class UserSignUpAnimeService {
                 .map(dto -> {
                     List<String> genreList = new ArrayList<>();
                     // 들어있는 장르가 null이 아니면서 3개 이상일 경우
-                    if (dto.getGenres() != null) {
-                        genreList.addAll(dto.getGenres());
-                    }
-
-                    if (genreList.size() >= 3) {
-                        List<String> genreTop3 = new ArrayList<>();
-                        genreTop3.add(genreList.get(0));
-                        genreTop3.add(genreList.get(1));
-                        genreTop3.add(genreList.get(2));
-
-                        if (genres != null && !genreTop3.contains(genresName)) {
-                            genreTop3.set(2, genresName);
-                        }
-                        genreList = genreTop3;
-                    }
+                    genreList = anime3GentePick(genres, dto, genreList, genresName);
                     return SignUpAnimeItemDto.of(
                             dto.getAnimeId(),
                             dto.getTitle(),
@@ -117,6 +103,25 @@ public class UserSignUpAnimeService {
         CursorDto cursor = CursorDto.of(nextId);
 
         return UserSignUpAnimePageDto.of(totalCount, cursor, result);
+    }
+
+    private static List<String> anime3GentePick(Long genres, SignUpPopularAnimeItemDto dto, List<String> genreList, String genresName) {
+        if (dto.getGenres() != null) {
+            genreList.addAll(dto.getGenres());
+        }
+
+        if (genreList.size() >= 3) {
+            List<String> genreTop3 = new ArrayList<>();
+            genreTop3.add(genreList.get(0));
+            genreTop3.add(genreList.get(1));
+            genreTop3.add(genreList.get(2));
+
+            if (genres != null && !genreTop3.contains(genresName)) {
+                genreTop3.set(2, genresName);
+            }
+            genreList = genreTop3;
+        }
+        return genreList;
     }
 
     private static SignUpAnimeExploreSearchRequestDto makeExploreSearchRequestDto(

--- a/src/main/resources/mapper/anime/MetaDataQueryMapper.xml
+++ b/src/main/resources/mapper/anime/MetaDataQueryMapper.xml
@@ -9,4 +9,10 @@
         FROM Genres
         ORDER BY genre_id
     </select>
+
+    <select id="selectGenresById" resultType="string">
+        SELECT genre_kor
+        FROM Genres g
+        WHERE g.genre_id = #{genresId}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/explore/UserSignUpAnimeQueryMapper.xml
+++ b/src/main/resources/mapper/explore/UserSignUpAnimeQueryMapper.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.anipick.backend.explore.mapper.UserSignUpAnimeMapper">
+
+    <select id="selectGenresByAnimeIds"
+            resultType="com.anipick.backend.explore.dto.AnimeIdGenreDto">
+        SELECT ag.anime_id AS animeId,
+               g.genre_kor AS genre
+        FROM animegenres ag
+            JOIN genres g
+                ON ag.genre_id = g.genre_id
+        WHERE ag.anime_id IN
+        <foreach collection="animeIds" item="id" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+        ORDER BY ag.anime_id, g.genre_kor
+    </select>
+
+    <select id="countExploredAndSearch"
+            parameterType="com.anipick.backend.explore.dto.SignUpAnimeExploreSearchRequestDto"
+            resultType="long">
+        SELECT COUNT(*)
+        FROM popularityanimeorder pa
+            JOIN anime a
+                ON pa.anime_id = a.anime_id
+        <where>
+            <!-- 검색 -->
+            <if test="query != null and query.trim() != ''">
+                AND a.title_search LIKE CONCAT('%', #{query}, '%')
+            </if>
+
+            <!-- 연도 분기 -->
+            <if test="startDate != null and endDate != null">
+                 AND a.start_date BETWEEN #{startDate} AND #{endDate}
+            </if>
+
+            <!-- 장르 -->
+            <if test="genres != null">
+                AND EXISTS (
+                    SELECT 1
+                    FROM animegenres ag2
+                    WHERE ag2.anime_id = a.anime_id
+                    AND ag2.genre_id = #{genres}
+                )
+            </if>
+        </where>
+
+    </select>
+
+     <select id="selectAnimeExploredAndSearch"
+          parameterType="com.anipick.backend.explore.dto.SignUpAnimeExploreSearchRequestDto"
+          resultType="com.anipick.backend.explore.dto.SignUpPopularAnimeItemDto">
+         SELECT pa.popularity_anime_order_id AS popularId,
+                a.anime_id AS animeId,
+                a.title_kor AS title,
+                a.cover_image_url AS coverImageUrl
+         FROM popularityanimeorder pa
+            JOIN anime a
+                ON pa.anime_id = a.anime_id
+         <where>
+             <!-- 검색 -->
+             <if test="query != null and query.trim() != ''">
+                 AND a.title_search LIKE CONCAT('%', #{query}, '%')
+             </if>
+
+             <!-- 연도 분기 -->
+             <if test="startDate != null and endDate != null">
+                 AND a.start_date BETWEEN #{startDate} AND #{endDate}
+             </if>
+
+             <!-- 장르 -->
+             <if test="genres != null">
+                 AND EXISTS (
+                     SELECT 1
+                     FROM animegenres ag2
+                     WHERE ag2.anime_id = a.anime_id
+                     AND ag2.genre_id = #{genres}
+                 )
+             </if>
+
+             <!-- 커서 -->
+             <if test="lastId != null">
+                 AND pa.popularity_anime_order_id > #{lastId}
+             </if>
+         </where>
+
+         ORDER BY pa.popularity_anime_order_id ASC
+         LIMIT #{size}
+  </select>
+
+</mapper>


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->


---

**work-details**

- 애니 평가 시 사용되는 애니 조회 (탐색 및 검색)
  - 기획에 따라 애니의 장르가 3개 이상일 경우 장르를 어떻게 보여줄지 나뉩니다.
    - 파라미터로 들어온 장르값이 현재 애니의 장르(0~2번째)에 포함될 경우
      - 0 ~ 2번째까지 장르를 저장, 리턴
    - 파라미터로 들어온 장르값이 현재 애니의 장르(0~2번째)에 포함되지 않을 경우
      - 0 ~ 2번째까지 장르를 저장, 2번째 값을 파라미터로 들어온 장르 값으로 대체

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
