### PR TITLE
fix/TAG_BASED 상태일 때 리뷰가 없는 경우 빈값 리턴

### DIFF
--- a/src/main/java/com/anipick/backend/recommendation/service/RecommendService.java
+++ b/src/main/java/com/anipick/backend/recommendation/service/RecommendService.java
@@ -16,8 +16,10 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Stack;
 
 @Service
 @RequiredArgsConstructor
@@ -84,6 +86,11 @@ public class RecommendService {
 
             List<Long> topRatedAnimeIds = reviewUserMapper.findTopRatedAnimeIds(userId, 20);
 
+            // 리뷰 데이터가 없는 경우
+            if (topRatedAnimeIds.isEmpty()) {
+                return UserMainRecommendationPageDto.of(null, CursorDto.of(null), List.of());
+            }
+            
             List<Long> filteredIds = topRatedAnimeIds.stream()
                     .filter(topRatedAnimeIds::contains)
                     .toList();

--- a/src/main/java/com/anipick/backend/recommendation/service/RecommendService.java
+++ b/src/main/java/com/anipick/backend/recommendation/service/RecommendService.java
@@ -68,6 +68,10 @@ public class RecommendService {
             referenceAnimeTitle = anime.getTitleKor();
             List<Long> tagIds = animeTagMapper.findTopTagsByAnime(referenceAnimeId, 5);
 
+            if (tagIds.isEmpty()) {
+                return UserMainRecommendationPageDto.of(null, CursorDto.of(null), List.of());
+            }
+
             RecentHighCountOnlyRequest request =
                     RecentHighCountOnlyRequest.of(userId, referenceAnimeId, tagIds, lastValue, lastId, size);
 


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 유저 추천모드가 `TAG_BASED` 상태일 때 리뷰 개수가 0일 경우
  - `TAG_BASED` 로직의 유저 고평가 애니들의 ID 가져오는 쿼리에서 ID 값들을 가져오지 못하는 이슈
  - 이후, IDS가 필요한 쿼리에 값을 넣지 못해 오류 발생


+++

- 07.28 추가
  - RECENT_HIGH 일 경우에도, 기준 애니의 tag 값이 아예 없는 경우
    - IDS가 필요한 쿼리에 값을 넣지 못해 오류 발생

---

**work-details**

- IDS 가져오는 쿼리에서 `isEmpty` 메서드를 통해 true일 경우 빈 값으로 리턴

- 07.28 추가
  - tag의 IDS 가져올 때, `isEmpty` 메서드를 통해 true일 경우 빈 값으로 리턴

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
