### PR TITLE
fix/isSpoiler 제거 및 카운트 쿼리 변경

### DIFF
--- a/src/main/java/com/anipick/backend/anime/controller/AnimeController.java
+++ b/src/main/java/com/anipick/backend/anime/controller/AnimeController.java
@@ -47,7 +47,6 @@ public class AnimeController {
 	public ApiResponse<AnimeDetailInfoReviewsPageDto> getAnimeInfoReviews(
 			@PathVariable(value = "animeId") Long animeId,
 			@RequestParam(value = "sort", defaultValue = "latest") String sort,
-			@RequestParam(value = "isSpoiler", defaultValue = "false") Boolean isSpoiler,
 			@RequestParam(value = "lastId", required = false) Long lastId,
 			@RequestParam(value = "lastValue", required = false) String lastValue,
 			@RequestParam(value = "size", defaultValue = "20") int size,
@@ -55,7 +54,7 @@ public class AnimeController {
 	) {
 		Long userId = user.getUserId();
 		AnimeDetailInfoReviewsPageDto result = animeService.getAnimeInfoReviews(
-				animeId, userId, sort, isSpoiler, lastId, lastValue, size
+				animeId, userId, sort, lastId, lastValue, size
 		);
 		return ApiResponse.success(result);
 	}

--- a/src/main/java/com/anipick/backend/anime/dto/AnimeDetailInfoReviewsRequestDto.java
+++ b/src/main/java/com/anipick/backend/anime/dto/AnimeDetailInfoReviewsRequestDto.java
@@ -10,7 +10,6 @@ public class AnimeDetailInfoReviewsRequestDto {
     private Long userId;
     private String sort;
     private String orderByQuery;
-    private Boolean isSpoiler;
     private Long lastId;
     private String lastValue;
     private int size;

--- a/src/main/java/com/anipick/backend/anime/service/AnimeService.java
+++ b/src/main/java/com/anipick/backend/anime/service/AnimeService.java
@@ -193,12 +193,12 @@ public class AnimeService {
 		return ComingSoonPageDto.of(totalCount, cursor, items);
 	}
   
-	public AnimeDetailInfoReviewsPageDto getAnimeInfoReviews(Long animeId, Long userId, String sort, Boolean isSpoiler, Long lastId, String lastValue, int size) {
+	public AnimeDetailInfoReviewsPageDto getAnimeInfoReviews(Long animeId, Long userId, String sort, Long lastId, String lastValue, int size) {
 		SortOption sortOption = SortOption.of(sort);
 		String orderByQuery = sortOption.getOrderByQuery();
 
 		AnimeDetailInfoReviewsRequestDto reviewsRequestDto =
-				AnimeDetailInfoReviewsRequestDto.of(animeId, userId, sort, orderByQuery, isSpoiler, lastId, lastValue, size);
+				AnimeDetailInfoReviewsRequestDto.of(animeId, userId, sort, orderByQuery, lastId, lastValue, size);
 
 		long totalCount = mapper.selectAnimeReviewCount(animeId);
 

--- a/src/main/resources/mapper/anime/AnimeQueryMapper.xml
+++ b/src/main/resources/mapper/anime/AnimeQueryMapper.xml
@@ -163,9 +163,6 @@
                     AND rl.user_id = #{userId}
         WHERE r.anime_id = #{animeId}
           AND r.content IS NOT NULL
-        <if test="isSpoiler == false">
-            AND r.is_spoiler = FALSE
-        </if>
         <!-- 커서 정렬 -->
         <choose>
             <!-- 최신순 -->
@@ -210,9 +207,10 @@
     </select>
 
     <select id="selectAnimeReviewCount" resultType="long">
-        SELECT a.review_count
-        FROM Anime a
-        WHERE a.anime_id = #{animeId}
+        SELECT COUNT(*)
+        FROM Review r
+        WHERE r.anime_id = #{animeId}
+          AND r.content IS NOT NULL
     </select>
 
     <select id="selectAnimeInfoDetail" resultType="com.anipick.backend.anime.dto.AnimeDetailInfoItemDto">


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- `isSpoiler`를 프론트 단에서 분기하여 처리
- 카운트 쿼리 비정규화 컬럼을 이용하기 때문에, `content IS NOT NULL` 과 정합성이 맞지 않음

---

**work-details**

- 기획과 프론트에 따라 요청 `isSpoiler` 제거
- 카운트 쿼리 `count` 함수 사용

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
