### PR TITLE
feat/마이페이지 - 프로필 사진 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation 'com.google.api-client:google-api-client:2.7.2'
     implementation 'com.google.oauth-client:google-oauth-client-jetty:1.39.0'
     implementation 'com.google.http-client:google-http-client-jackson2:1.43.3'
+    implementation 'commons-io:commons-io:2.14.0'
+    implementation 'net.coobird:thumbnailator:0.4.14'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/anipick/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/anipick/backend/common/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(
                         auth ->
-                                auth.requestMatchers("/api/users/**", "/api/auth/**", "/api/oauth/**", "/api/animes/meta-data-group")
+                                auth.requestMatchers("/api/users/**", "/api/auth/**", "/api/oauth/**", "/api/animes/meta-data-group", "/images/profile/**")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated()

--- a/src/main/java/com/anipick/backend/common/config/WebConfig.java
+++ b/src/main/java/com/anipick/backend/common/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.anipick.backend.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/profile/**")
+                .addResourceLocations("file:" + uploadDir);
+    }
+}

--- a/src/main/java/com/anipick/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/anipick/backend/common/exception/ErrorCode.java
@@ -69,7 +69,11 @@ public enum ErrorCode {
 	 * LIKE
 	 */
 	LIKE_DATA_NOT_FOUND(801, "좋아요 데이터 찾을 수 없음", null),
-	ALREADY_LIKE_DATA(802, "좋아요 데이터가 이미 존재", null);
+	ALREADY_LIKE_DATA(802, "좋아요 데이터가 이미 존재", null),
+	/**
+	 * Image
+	 */
+	INVAILD_IMAGE_EXTENSION(901, "유효한 이미지 확장자가 아님", null);
 
 	private final int code;
 	private final String errorReason;

--- a/src/main/java/com/anipick/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/anipick/backend/common/exception/GlobalExceptionHandler.java
@@ -15,7 +15,7 @@ public class GlobalExceptionHandler {
 	// CustomException
 	@ExceptionHandler(CustomException.class)
 	public ApiResponse<?> handleBusiness(CustomException ex) {
-		log.error("log info {} : ", ex.getErrorCode().getErrorReason());
+		log.error("log info : ", ex);
 		ErrorCode ec = ex.getErrorCode();
 		return ApiResponse.error(ec);
 	}
@@ -30,7 +30,7 @@ public class GlobalExceptionHandler {
 	// 그 외 모든 예외 (서버 오류)
 	@ExceptionHandler(Exception.class)
 	public ApiResponse<?> handleAll(Exception ex) {
-		log.error("log info {} : ", ex.getMessage());
+		log.error("log info : ", ex);
 		return ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR);
 	}
 }

--- a/src/main/java/com/anipick/backend/mypage/controller/MyPageController.java
+++ b/src/main/java/com/anipick/backend/mypage/controller/MyPageController.java
@@ -6,10 +6,8 @@ import com.anipick.backend.mypage.dto.*;
 import com.anipick.backend.mypage.service.MyPageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +19,16 @@ public class MyPageController {
     public ApiResponse<MyPageResponse> getMyPage(@AuthenticationPrincipal CustomUserDetails user) {
         Long userId = user.getUserId();
         MyPageResponse response = myPageService.getMyPage(userId);
+        return ApiResponse.success(response);
+    }
+
+    @PostMapping("/profile-image")
+    public ApiResponse<ProfileImageResponse> updateProfileImage(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestPart("profileImageRequest") ProfileImageRequest request,
+            @RequestPart("profileImageFile") MultipartFile profileImageFile
+    ) {
+        ProfileImageResponse response = myPageService.updateProfileImage(user, request, profileImageFile);
         return ApiResponse.success(response);
     }
 

--- a/src/main/java/com/anipick/backend/mypage/domain/MyPageDefaults.java
+++ b/src/main/java/com/anipick/backend/mypage/domain/MyPageDefaults.java
@@ -5,5 +5,5 @@ import lombok.Getter;
 @Getter
 public class MyPageDefaults {
     public static final Integer DEFAULT_PAGE_SIZE = 10;
-    public static final String DEFAULT_SORT_OPTION = "createdAt";
+    public static final String PROFILE_IMAGE_FORMAT = "/images/profile/";
 }

--- a/src/main/java/com/anipick/backend/mypage/dto/ProfileImageRequest.java
+++ b/src/main/java/com/anipick/backend/mypage/dto/ProfileImageRequest.java
@@ -1,0 +1,8 @@
+package com.anipick.backend.mypage.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ProfileImageRequest {
+    private String profileImageUrl;
+}

--- a/src/main/java/com/anipick/backend/mypage/dto/ProfileImageResponse.java
+++ b/src/main/java/com/anipick/backend/mypage/dto/ProfileImageResponse.java
@@ -1,0 +1,14 @@
+package com.anipick.backend.mypage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProfileImageResponse {
+    private String profileImageUrl;
+
+    public static ProfileImageResponse from(String profileImageUrl) {
+        return new ProfileImageResponse(profileImageUrl);
+    }
+}

--- a/src/main/java/com/anipick/backend/user/mapper/UserMapper.java
+++ b/src/main/java/com/anipick/backend/user/mapper/UserMapper.java
@@ -22,6 +22,7 @@ public interface UserMapper {
     void updateUserNickname(@Param("userId") Long userId, @Param("nickname") String nickname);
     void updateUserEmail(@Param("userId") Long userId, @Param("email") String email);
     void updateUserByWithdrawal(@Param("userId") Long userId, @Param("nickname") String nickname);
+    void updateUserProfileImage(@Param("userId") Long userId, @Param("profileImageUrl") String profileImageUrl);
 
     void deleteUserById(Long userId);
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,6 +9,13 @@ spring:
   config:
     activate:
       on-profile: local-mysql
+
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}
@@ -32,6 +39,7 @@ spring:
         smtp.timeout: 180000
         smtp.writetimeout: 180000
         smtp.starttls.enable: true
+
 ---
 jwt:
   secret-key: ${SECRET_KEY}
@@ -46,3 +54,6 @@ app:
     google:
       android-client-id: ${ANDROID_CLIENT_ID}
       ios-client-id: ${IOS_CLIENT_ID}
+
+file:
+  upload-dir: ./uploads/images/profile/

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -9,6 +9,13 @@ spring:
   config:
     activate:
       on-profile: prod-mysql
+
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}
@@ -46,3 +53,6 @@ app:
     google:
       android-client-id: ${ANDROID_CLIENT_ID}
       ios-client-id: ${IOS_CLIENT_ID}
+
+file:
+  upload-dir: ./uploads/images/profile/

--- a/src/main/resources/mapper/user/UserCommandMapper.xml
+++ b/src/main/resources/mapper/user/UserCommandMapper.xml
@@ -44,4 +44,10 @@
             deleted_at = NOW()
         WHERE user_id = #{userId}
     </update>
+
+    <update id="updateUserProfileImage">
+        UPDATE user
+        SET profile_image_url = #{profileImageUrl}
+        WHERE user_id = #{userId}
+    </update>
 </mapper>


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->
* 프로필 사진을 변경하는 로직을 추가하였습니다. 

---

**work-details**
1. 프론트 단에서 받은 사진을 리사이징 및 압축합니다.
2. 압축한 사진을 서버에 저장합니다.
3. 저장한 사진을 프론트에게 다시 url을 전달합니다.

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->
* 성공 시
<img width="1547" height="633" alt="image" src="https://github.com/user-attachments/assets/cd08e43d-ad20-419b-9c5c-6811a86f26cb" />


### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test
