### PR TITLE
fix/마이페이지 이미지 관련 로직을 이미지 도메인으로 이동

### DIFF
--- a/src/main/java/com/anipick/backend/image/mapper/ImageMapper.java
+++ b/src/main/java/com/anipick/backend/image/mapper/ImageMapper.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 @Mapper
 public interface ImageMapper {
     void insertImage(Image image);
+    void deleteImage(@Param("imageId") Long imageId);
 
     Optional<Image> findByImageId(@Param("imageId") Long imageId);
 

--- a/src/main/java/com/anipick/backend/image/service/ImageService.java
+++ b/src/main/java/com/anipick/backend/image/service/ImageService.java
@@ -1,0 +1,104 @@
+package com.anipick.backend.image.service;
+
+import com.anipick.backend.common.auth.dto.CustomUserDetails;
+import com.anipick.backend.common.exception.CustomException;
+import com.anipick.backend.common.exception.ErrorCode;
+import com.anipick.backend.image.domain.Image;
+import com.anipick.backend.image.mapper.ImageMapper;
+import lombok.RequiredArgsConstructor;
+import net.coobird.thumbnailator.Thumbnails;
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    private final ImageMapper imageMapper;
+
+    public File compressAndSaveImageToServer(CustomUserDetails user, MultipartFile imageFile) throws IOException {
+        String originalFilename = imageFile.getOriginalFilename();
+        String uploadImageUrl;
+
+        BufferedImage bufferedImage = ImageIO.read(imageFile.getInputStream());
+        if(bufferedImage == null) {
+            throw new CustomException(ErrorCode.INVAILD_IMAGE_EXTENSION);
+        }
+
+        byte[] compressedBytes = compressImageWithThumbnailator(imageFile);
+        uploadImageUrl = getUploadImageUrl(originalFilename, user.getUserId());
+
+        File directory = new File(uploadDir);
+        if(!directory.exists()) {
+            directory.mkdirs();
+        }
+
+        File outputFile = new File(directory, uploadImageUrl);
+        try(FileOutputStream fileOutputStream = new FileOutputStream(outputFile)) {
+            fileOutputStream.write(compressedBytes);
+        }
+
+        return outputFile;
+    }
+
+    public Image insertImage(CustomUserDetails user, String originalFilename, File outputFile) {
+        Image image = Image.builder()
+                .authId(user.getUserId())
+                .imageName(originalFilename)
+                .imagePath(outputFile.getAbsolutePath())
+                .build();
+
+        imageMapper.insertImage(image);
+        return image;
+    }
+
+    public Resource getImageResourceOnServer(Long imageId) {
+        Image image = imageMapper.findByImageId(imageId)
+                .orElseThrow(() -> new CustomException(ErrorCode.IMAGE_DATA_NOT_FOUND));
+        String imagePath = image.getImagePath();
+        Path filePath = Paths.get(imagePath);
+
+        return new FileSystemResource(filePath);
+    }
+
+    public Image getImage(Long imageId) {
+        return imageMapper.findByImageId(imageId)
+                .orElseThrow(() -> new CustomException(ErrorCode.IMAGE_DATA_NOT_FOUND));
+    }
+
+    public void deleteImage(Long imageId) {
+        imageMapper.deleteImage(imageId);
+    }
+
+    private String getUploadImageUrl(String fileName, Long userId) {
+        String baseName = FilenameUtils.getBaseName(fileName);
+        String extension = FilenameUtils.getExtension(fileName);
+        return userId + System.currentTimeMillis() + baseName + "." + extension;
+    }
+
+    private byte[] compressImageWithThumbnailator(MultipartFile file) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        Thumbnails.of(file.getInputStream())
+                .size(800, 800)
+                .outputQuality(0.7)
+                .toOutputStream(outputStream);
+
+        return outputStream.toByteArray();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -56,4 +56,4 @@ app:
       ios-client-id: ${IOS_CLIENT_ID}
 
 file:
-  upload-dir: ./uploads/images/profile/
+  upload-dir: ${FILE_UPLOAD_DIR}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -55,4 +55,4 @@ app:
       ios-client-id: ${IOS_CLIENT_ID}
 
 file:
-  upload-dir: ./uploads/images/profile/
+  upload-dir: ${FILE_UPLOAD_DIR}

--- a/src/main/resources/mapper/image/ImageCommandMapper.xml
+++ b/src/main/resources/mapper/image/ImageCommandMapper.xml
@@ -9,4 +9,9 @@
         VALUES
             (#{authId}, #{imageName}, #{imagePath})
     </insert>
+
+    <delete id="deleteImage">
+        DELETE FROM Image
+        WHERE image_id = #{imageId}
+    </delete>
 </mapper>


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->
- 현재 이미지 업데이트 및 이미지 조회 로직은 마이페이지 도메인에 존재
- 현재 이미지 도메인에서의 로직을 마이페이지 도메인이 의존하는 것이 아님 
- 마이페이지 도메인 자체에서 이미지 관련 로직이 개발됨 -> 따라서 이미지 도메인으로 해당 로직을 이동

---

**work-details**

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
