### PR TITLE
fix/review 조회 로직의 필드 추가함에 따라 테스트 코드 변경

### DIFF
--- a/src/test/java/com/anipick/backend/AnipickBackendApplicationTests.java
+++ b/src/test/java/com/anipick/backend/AnipickBackendApplicationTests.java
@@ -1,9 +1,7 @@
 package com.anipick.backend;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 class AnipickBackendApplicationTests {
 
     @Test

--- a/src/test/java/com/anipick/backend/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/anipick/backend/review/service/ReviewServiceTest.java
@@ -40,7 +40,7 @@ class ReviewServiceTest {
         given(mapper.countRecentReviews(userId)).willReturn(50L);
 
         RecentReviewItemDto sampleDto = new RecentReviewItemDto(
-                10L, 123L, "타이틀", "url",
+                10L, userId,123L, "타이틀", "url",
                 4.5, "내용43254", "345efew", "imgUrl",
                 "2025-05-03 17:16:46", 3L, true, false
         );


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 현재 서버는 아래의 명령어대로 `-x test` 구성돼 빌드를 하고 있습니다.
```
# 빌드
echo "Gradle 빌드를 시작합니다..." >> $BUILD_LOG_FILE
chmod +x gradlew
./gradlew clean build -x test >> $BUILD_LOG_FILE 2>&1
```
- 테스트 깨짐을 관리하고자, `-x test`를 제거하여 배포하려고 변경합니다.

---

**work-details**

- https://github.com/Anipick-Team/anipick-backend/issues/222 에도 적었지만, 똑같이 이 PR에도 적어 놓겠습니다.

---

- https://github.com/Anipick-Team/anipick-backend/pull/217 에서 userId 필드를 추가하게 돼서 ReviewServiceTest의 firstPageSuccess 테스트 메서드가 컴파일 에러 나고 있습니다. 따라서 userId 값도 같이 생성합니다. (setUp userId 의 값으로 넣습니다.)
- **메인 클래스의 테스트 코드가 동작하지 않습니다.** _SpringBootTest 어노테이션 삭제합니다_.
  - 제대로 동작하지 않는 이유는 테스트 컨텍스트가 DB를 만들려 하는데, 드라이버 / URL 설정이 없어서 실패하는 거 같습니다.
  - 제가 보기엔....yml에서 따로 환경변수 주입을 통해 넣고 있는데 이를 확인할 수 없어서 그런 거 같아요. 아마도..?
  - [test 코드 작성하지 않았다면...](https://velog.io/@pshsh910/TDD-cloud%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-gradle-%EC%8B%A4%ED%96%89-%EC%8B%9C-test%EA%B3%BC%EC%A0%95-contextLoads-FAILED-%EC%98%A4%EB%A5%98)
  - [프로퍼티 값이 주입이 되지 않을 때는 .. 1](https://yunchan97.tistory.com/96)
  - [프로퍼티 값이 주입이 되지 않을 때는 .. 2](https://ayasetaka.tistory.com/30)


**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

<img width="285" height="187" alt="image" src="https://github.com/user-attachments/assets/b900854e-7b88-4e9d-8838-c4891158ac51" />


### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test
