### PR TITLE
fix/랜덤 닉네임 생성 thread-safe하게 변경 & 동시성 테스트 적용

### DIFF
--- a/src/main/java/com/anipick/backend/user/component/NicknameInitializer.java
+++ b/src/main/java/com/anipick/backend/user/component/NicknameInitializer.java
@@ -11,22 +11,21 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
 public class NicknameInitializer {
     private static final int NICKNAME_THRESHOLD = 1000;
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS");
     private static final String COLON = ":";
 
     private final RedisTemplate<String, String> redisTemplate;
 
     public String generateNickname(LoginFormat loginFormat) {
-        String timeStamp = LocalDateTime.now().format(DATE_TIME_FORMATTER);
+        String randomUuid = UUID.randomUUID().toString().substring(0, 8);
         String loginFormatFirstLetter = loginFormat.toString().substring(0, 1);
-        String redisKey = UserDefaults.DEFAULT_NICKNAME_FORMAT_KEY + loginFormat + COLON + timeStamp;
+        String redisKey = UserDefaults.DEFAULT_NICKNAME_FORMAT_KEY + loginFormat + COLON + randomUuid;
         Long count = redisTemplate.opsForValue().increment(redisKey);
 
         if(count == null) {
@@ -42,6 +41,6 @@ public class NicknameInitializer {
         int tailCount = (int) ((count - 1L) % NICKNAME_THRESHOLD);
         String tailNickname = String.format("%03d", tailCount);
 
-        return loginFormatFirstLetter + timeStamp + tailNickname;
+        return loginFormatFirstLetter + randomUuid + tailNickname;
     }
 }

--- a/src/main/java/com/anipick/backend/user/component/NicknameInitializer.java
+++ b/src/main/java/com/anipick/backend/user/component/NicknameInitializer.java
@@ -6,37 +6,42 @@ import com.anipick.backend.user.domain.LoginFormat;
 import com.anipick.backend.user.domain.UserDefaults;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Component
 @RequiredArgsConstructor
 public class NicknameInitializer {
-    private static final int NICKNAME_THRESHOLD = 10;
+    private static final int NICKNAME_THRESHOLD = 1000;
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS");
+    private static final String COLON = ":";
 
     private final RedisTemplate<String, String> redisTemplate;
 
     public String generateNickname(LoginFormat loginFormat) {
-        String redisKey = UserDefaults.DEFAULT_NICKNAME_FORMAT_KEY + loginFormat;
+        String timeStamp = LocalDateTime.now().format(DATE_TIME_FORMATTER);
+        String loginFormatFirstLetter = loginFormat.toString().substring(0, 1);
+        String redisKey = UserDefaults.DEFAULT_NICKNAME_FORMAT_KEY + loginFormat + COLON + timeStamp;
         Long count = redisTemplate.opsForValue().increment(redisKey);
 
         if(count == null) {
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
 
-        if(count >= NICKNAME_THRESHOLD) {
-            redisTemplate.delete(redisKey);
+        synchronized (this) {
+            if(count == 1L) {
+                redisTemplate.expire(redisKey, Duration.ofSeconds(10));
+            }
         }
 
-        long normalizedCount = count % NICKNAME_THRESHOLD;
-        String timeStamp = LocalDateTime.now().format(DATE_TIME_FORMATTER);
-        String loginFormatFirstLetter = loginFormat.toString().substring(0, 1);
-        String nickname = loginFormatFirstLetter + timeStamp + normalizedCount;
+        int tailCount = (int) ((count - 1L) % NICKNAME_THRESHOLD);
+        String tailNickname = String.format("%03d", tailCount);
 
-        return nickname;
+        return loginFormatFirstLetter + timeStamp + tailNickname;
     }
 }

--- a/src/test/java/com/anipick/backend/user/component/NicknameInitializerConcurrencyTest.java
+++ b/src/test/java/com/anipick/backend/user/component/NicknameInitializerConcurrencyTest.java
@@ -1,0 +1,76 @@
+package com.anipick.backend.user.component;
+
+import com.anipick.backend.user.domain.LoginFormat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class NicknameInitializerConcurrencyTest {
+    @Autowired
+    NicknameInitializer nicknameInitializer;
+
+    @Test
+    @DisplayName("동시에 100개를 발급하고 중복이 없거나 길이가 20자여야 한다.")
+    void concurrencyTest() throws InterruptedException {
+        int threads = 100;
+        int perThread = 100;
+        int total = threads * perThread;
+
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done  = new CountDownLatch(threads);
+
+        // 결과 수집
+        Set<String> nicknames = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        List<Future<?>> futures = new ArrayList<>(threads);
+
+        for (int t = 0; t < threads; t++) {
+            futures.add(pool.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    for (int i = 0; i < perThread; i++) {
+                        String nickname = nicknameInitializer.generateNickname(LoginFormat.LOCAL);
+                        // 길이(20자)와 중복 여부 확인
+                        if (nickname.length() != 20) {
+                            throw new AssertionError("length != 20: " + nickname);
+                        }
+                        if (!nicknames.add(nickname)) {
+                            throw new AssertionError("duplicate: " + nickname);
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            }));
+        }
+
+        // 동시에 시작
+        ready.await();
+        long begin = System.nanoTime();
+        start.countDown();
+        done.await();
+        long elapsedMs = (System.nanoTime() - begin) / 1_000_000;
+
+        // 정리
+        pool.shutdown();
+
+        // 최종 검증
+        assertThat(nicknames).hasSize(total);
+        System.out.println("Generated: " + total + " in " + elapsedMs + " ms");
+    }
+}

--- a/src/test/java/com/anipick/backend/user/component/NicknameInitializerConcurrencyTest.java
+++ b/src/test/java/com/anipick/backend/user/component/NicknameInitializerConcurrencyTest.java
@@ -1,76 +1,86 @@
 package com.anipick.backend.user.component;
 
 import com.anipick.backend.user.domain.LoginFormat;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
+import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class NicknameInitializerConcurrencyTest {
-    @Autowired
+    @Mock
+    RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    ValueOperations<String, String> valueOps;
+
+    @InjectMocks
     NicknameInitializer nicknameInitializer;
 
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(redisTemplate.expire(anyString(), any(Duration.class))).thenReturn(true);
+
+        ConcurrentHashMap<String, AtomicLong> counters = new ConcurrentHashMap<>();
+        when(valueOps.increment(anyString())).thenAnswer(inv -> {
+            String key = inv.getArgument(0);
+            return counters.computeIfAbsent(key, k -> new AtomicLong(0)).incrementAndGet();
+        });
+    }
+
     @Test
-    @DisplayName("동시에 100개를 발급하고 중복이 없거나 길이가 20자여야 한다.")
-    void concurrencyTest() throws InterruptedException {
+    @DisplayName("랜덤 닉네임을 1ms에 동시적으로 10000개를 발급한다. 그리고 중복이 없거나 길이가 12자여야 한다.")
+    void nicknameConcurrencyTest() throws InterruptedException, ExecutionException {
         int threads = 100;
         int perThread = 100;
         int total = threads * perThread;
 
         ExecutorService pool = Executors.newFixedThreadPool(threads);
-        CountDownLatch ready = new CountDownLatch(threads);
         CountDownLatch start = new CountDownLatch(1);
-        CountDownLatch done  = new CountDownLatch(threads);
-
-        // 결과 수집
-        Set<String> nicknames = Collections.newSetFromMap(new ConcurrentHashMap<>());
-        List<Future<?>> futures = new ArrayList<>(threads);
+        Set<String> nicknames = ConcurrentHashMap.newKeySet();
+        List<Future<?>> futures = new ArrayList<>();
 
         for (int t = 0; t < threads; t++) {
             futures.add(pool.submit(() -> {
-                ready.countDown();
-                try {
-                    start.await();
-                    for (int i = 0; i < perThread; i++) {
-                        String nickname = nicknameInitializer.generateNickname(LoginFormat.LOCAL);
-                        // 길이(20자)와 중복 여부 확인
-                        if (nickname.length() != 20) {
-                            throw new AssertionError("length != 20: " + nickname);
-                        }
-                        if (!nicknames.add(nickname)) {
-                            throw new AssertionError("duplicate: " + nickname);
-                        }
+                start.await();
+
+                for (int i = 0; i < perThread; i++) {
+                    String nickname = nicknameInitializer.generateNickname(LoginFormat.LOCAL);
+                    assertEquals(12, nickname.length(), "length != 12: " + nickname);
+                    if (!nicknames.add(nickname)) {
+                        throw new AssertionError("duplicate: " + nickname);
                     }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } finally {
-                    done.countDown();
                 }
+
+                return null;
             }));
         }
 
-        // 동시에 시작
-        ready.await();
-        long begin = System.nanoTime();
         start.countDown();
-        done.await();
-        long elapsedMs = (System.nanoTime() - begin) / 1_000_000;
-
-        // 정리
+        for (Future<?> f : futures) {
+            f.get();
+        }
         pool.shutdown();
 
-        // 최종 검증
-        assertThat(nicknames).hasSize(total);
-        System.out.println("Generated: " + total + " in " + elapsedMs + " ms");
+        assertEquals(total, nicknames.size());
     }
 }


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->
현재 랜덤 닉네임을 동시적으로 생성할 시 닉네임이 중복될 수 있다는 동시성 이슈가 존재합니다.
따라서 이에 따라 멀티스레드 환경에서도 thread-safe 할 수 있게 로직을 변경합니다.

---

**work-details**
1. 기존 DateTimeFormatter 밀리초 단위로 적용하는 것을 삭제하고 UUID.randomUUID.toString()을 substring 한 값으로 적용하였습니다.
2. 1ms에 동시적으로 랜덤 닉네임 10000개를 생성하여 중복이 있는지, 닉네임 글자 수가 12자인지 확인하는 동시성 테스트를 진행하였습니다.

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->
* 테스트 성공 로직
<img width="2250" height="462" alt="image" src="https://github.com/user-attachments/assets/32940cb7-042e-4a6d-92ac-256e26cfdb57" />


### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test
