### PR TITLE
fix/리뷰 유저 프로필 가져오기 수정

### DIFF
--- a/src/main/java/com/anipick/backend/anime/service/AnimeService.java
+++ b/src/main/java/com/anipick/backend/anime/service/AnimeService.java
@@ -40,7 +40,7 @@ public class AnimeService {
 
 	private static final DateTimeFormatter parser = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy. MM. dd");
-	private static final String IMAGE_URL = "https://anipick.p-e.kr/api/image/";
+	private static final String IMAGE_URL = "/api/image/";
 
 
 	public UpcomingSeasonResultDto getUpcomingSeasonAnimes() {

--- a/src/main/java/com/anipick/backend/anime/service/AnimeService.java
+++ b/src/main/java/com/anipick/backend/anime/service/AnimeService.java
@@ -40,6 +40,8 @@ public class AnimeService {
 
 	private static final DateTimeFormatter parser = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy. MM. dd");
+	private static final String IMAGE_URL = "https://anipick.p-e.kr/api/image/";
+
 
 	public UpcomingSeasonResultDto getUpcomingSeasonAnimes() {
 		LocalDate now = LocalDate.now();
@@ -209,11 +211,19 @@ public class AnimeService {
 					LocalDateTime dateTime = LocalDateTime.parse(dto.getCreatedAt(), parser);
 					String formattedDate = dateTime.format(formatter);
 
+					String combinationUserImageUrl;
+					String imageId = dto.getProfileImageUrl();
+					if (imageId == null) {
+						combinationUserImageUrl = IMAGE_URL + "-1";
+					} else {
+						combinationUserImageUrl = IMAGE_URL + imageId;
+					}
+
 					return AnimeDetailInfoReviewsResultDto.of(
 							dto.getReviewId(),
 							dto.getUserId(),
 							dto.getNickname(),
-							dto.getProfileImageUrl(),
+							combinationUserImageUrl,
 							dto.getRating(),
 							dto.getContent(),
 							formattedDate,

--- a/src/main/java/com/anipick/backend/review/service/ReviewService.java
+++ b/src/main/java/com/anipick/backend/review/service/ReviewService.java
@@ -39,7 +39,7 @@ public class ReviewService {
 
     private static final DateTimeFormatter parser = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy. MM. dd");
-    private static final String IMAGE_URL = "https://anipick.p-e.kr/api/image/";
+    private static final String IMAGE_URL = "/api/image/";
 
     @Transactional(readOnly = true)
     public RecentReviewPageDto getRecentReviews(Long userId, Long lastId, Integer size) {

--- a/src/main/java/com/anipick/backend/review/service/ReviewService.java
+++ b/src/main/java/com/anipick/backend/review/service/ReviewService.java
@@ -39,6 +39,7 @@ public class ReviewService {
 
     private static final DateTimeFormatter parser = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy. MM. dd");
+    private static final String IMAGE_URL = "https://anipick.p-e.kr/api/image/";
 
     @Transactional(readOnly = true)
     public RecentReviewPageDto getRecentReviews(Long userId, Long lastId, Integer size) {
@@ -53,6 +54,14 @@ public class ReviewService {
                     LocalDateTime dateTime = LocalDateTime.parse(dto.getCreatedAt(), parser);
                     String formattedDate = dateTime.format(formatter);
 
+                    String combinationUserImageUrl;
+                    String imageId = dto.getProfileImageUrl();
+                    if (imageId == null) {
+                        combinationUserImageUrl = IMAGE_URL + "-1";
+                    } else {
+                        combinationUserImageUrl = IMAGE_URL + imageId;
+                    }
+
                     return RecentReviewItemDto.builder()
                             .reviewId(dto.getReviewId())
                             .userId(dto.getUserId())
@@ -62,7 +71,7 @@ public class ReviewService {
                             .rating(dto.getRating())
                             .reviewContent(dto.getReviewContent())
                             .nickname(dto.getNickname())
-                            .profileImageUrl(dto.getProfileImageUrl())
+                            .profileImageUrl(combinationUserImageUrl)
                             .createdAt(formattedDate)
                             .likeCount(dto.getLikeCount())
                             .likedByCurrentUser(dto.getLikedByCurrentUser())

--- a/src/main/resources/mapper/anime/AnimeQueryMapper.xml
+++ b/src/main/resources/mapper/anime/AnimeQueryMapper.xml
@@ -148,7 +148,8 @@
         SELECT r.review_id AS reviewId,
                u.user_id AS userId,
                u.nickname AS nickname,
-               u.profile_image_url AS profileImageUrl,
+        -- profiler_image_url -> image.image_id 로 변경
+               i.image_id AS profileImageUrl,
                r.rating AS rating,
                r.content AS content,
                r.created_at AS createdAt,
@@ -162,6 +163,8 @@
             LEFT JOIN reviewlike rl
                 ON rl.review_id = r.review_id
                     AND rl.user_id = #{userId}
+            LEFT JOIN Image i
+            ON i.auth_id = u.user_id
         WHERE r.anime_id = #{animeId}
           AND r.content IS NOT NULL
         <!-- 커서 정렬 -->

--- a/src/main/resources/mapper/review/RecentReviewQueryMapper.xml
+++ b/src/main/resources/mapper/review/RecentReviewQueryMapper.xml
@@ -30,7 +30,8 @@
             r.rating,
             r.content AS reviewContent,
             u.nickname,
-            u.profile_image_url AS profileImageUrl,
+        -- profiler_image_url -> image.image_id 로 변경
+            i.image_id AS profileImageUrl,
             r.created_at AS createdAt,
             r.like_count AS likeCount,
         -- 내가 좋아요 눌렀는지
@@ -45,6 +46,9 @@
         LEFT JOIN ReviewLike rl
             ON rl.review_id = r.review_id
         AND rl.user_id = #{currentUserId}
+
+        LEFT JOIN Image i
+            ON i.auth_id = u.user_id
 
         WHERE r.is_spoiler = FALSE
         AND r.content IS NOT NULL


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 기존 : `User` 테이블에서 `profile_image_url` 컬럼을 통해 절대경로로 가져왔음.
- 변경 : `User.profile_image_url`삭제, `Image` 테이블 생성
  - `image` 조회 API URL 호출하도록 API URL 값으로 변경
  - `profile_image_url` 필드명은 그대로 두었습니다. 바꾸면 프론트 쪽에서도 변경된 필드명에 따라 또 맞춰야 하기 때문에...

---

**work-details**

- 리뷰들을 조회할 때 image 테이블을 left join 처리하여 imageId 값들을 같이 가져 옵니다.
  - null인 경우 `-1` 값으로 처리

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
