### PR TITLE
fix/애니 상세의 애니 평점 반올림 처리

### DIFF
--- a/src/main/java/com/anipick/backend/anime/dto/AnimeDetailInfoItemDto.java
+++ b/src/main/java/com/anipick/backend/anime/dto/AnimeDetailInfoItemDto.java
@@ -13,7 +13,7 @@ public class AnimeDetailInfoItemDto {
     private String coverImageUrl;
     private String bannerImageUrl;
     private String description;
-    private String averageRating;
+    private Double averageRating;
     private Boolean isLiked;
     private UserAnimeOfStatus watchStatus;
     private String type;
@@ -22,4 +22,11 @@ public class AnimeDetailInfoItemDto {
     private LocalDate startDate;
     private AnimeStatus status;
     private String age;
+
+    public String getAverageRatingAsString() {
+        if (averageRating == null) {
+            return null;
+        }
+        return String.format("%.1f", averageRating);
+    }
 }

--- a/src/main/java/com/anipick/backend/anime/service/AnimeService.java
+++ b/src/main/java/com/anipick/backend/anime/service/AnimeService.java
@@ -355,7 +355,7 @@ public class AnimeService {
 				.coverImageUrl(animeDetailInfoItemDto.getCoverImageUrl())
 				.bannerImageUrl(animeDetailInfoItemDto.getBannerImageUrl())
 				.description(animeDetailInfoItemDto.getDescription())
-				.averageRating(animeDetailInfoItemDto.getAverageRating())
+				.averageRating(animeDetailInfoItemDto.getAverageRatingAsString())
 				.isLiked(animeDetailInfoItemDto.getIsLiked())
 				.watchStatus(animeDetailInfoItemDto.getWatchStatus())
 				.type(type)


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 애니 상세에서 애니의 평점을 조회할 때, 반올림처리 되지 않아 소수점 자리가 길어졌음. (ex. 4.16666666667)

---

**work-details**

- 애니 상세의 애니 평점 조회 시 평점 첫째자리까지 반올림 처리 (ex. 4.166666667 -> 4.2)

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
