### PR TITLE
fix/중복된 이미지를 처리하는 로직 추가

### DIFF
--- a/src/main/java/com/anipick/backend/image/controller/ImageController.java
+++ b/src/main/java/com/anipick/backend/image/controller/ImageController.java
@@ -15,8 +15,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Optional;
 
 @RestController

--- a/src/main/java/com/anipick/backend/image/mapper/ImageMapper.java
+++ b/src/main/java/com/anipick/backend/image/mapper/ImageMapper.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 @Mapper
 public interface ImageMapper {
     void insertImage(Image image);
+    void updateImageByUserId(Image image, @Param("userId") Long userId);
     void deleteImage(@Param("imageId") Long imageId);
 
     Optional<Image> findByImageId(@Param("imageId") Long imageId);

--- a/src/main/resources/mapper/image/ImageCommandMapper.xml
+++ b/src/main/resources/mapper/image/ImageCommandMapper.xml
@@ -10,6 +10,14 @@
             (#{authId}, #{imageName}, #{imagePath})
     </insert>
 
+    <update id="updateImageByUserId" parameterType="com.anipick.backend.image.domain.Image">
+        UPDATE Image
+        SET
+            image_name = #{image.imageName},
+            image_path = #{image.imagePath}
+        WHERE auth_id = #{userId}
+    </update>
+
     <delete id="deleteImage">
         DELETE FROM Image
         WHERE image_id = #{imageId}


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->
* 이미지 업데이트를 2번 이상 할 시 한명의 유저에게 2개 이상의 프로필 이미지가 조회되어
정합성이 맞지 않는 이슈가 발생하여 이를 수정합니다.

---

**work-details**
1. image가 존재하면 update, image가 존재하지 않으면 insert 합니다.


**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test
