### PR TITLE
fix/pao 테이블 삭제로 인한 인기순 코드 변경

### DIFF
--- a/src/main/java/com/anipick/backend/common/domain/SortOption.java
+++ b/src/main/java/com/anipick/backend/common/domain/SortOption.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SortOption {
 	LATEST("latest", "a.anime_id DESC"),
-	POPULARITY("popularity", "pao.score DESC"),
+	POPULARITY("popularity", "a.popularity DESC"),
 	START_DATE("startDate", "a.start_date ASC"),
 	RATING_DESC("ratingDesc", "r.rating DESC"),
 	RATING_ASC("ratingAsc", "r.rating ASC"),

--- a/src/main/java/com/anipick/backend/mypage/service/MyPageService.java
+++ b/src/main/java/com/anipick/backend/mypage/service/MyPageService.java
@@ -44,7 +44,7 @@ public class MyPageService {
                 .stream()
                 .map(LikedPersonsDto::personNameTranslationPick)
                 .toList();
-      
+
         Optional<Image> image = imageService.getImageByAuthId(userId);
       
         String imageUrl;

--- a/src/main/resources/mapper/anime/AnimeQueryMapper.xml
+++ b/src/main/resources/mapper/anime/AnimeQueryMapper.xml
@@ -14,11 +14,9 @@
                a.title_native AS titleNat,
                a.cover_image_url AS coverImageUrl
         FROM Anime a
-        JOIN PopularityAnimeOrder pao
-            ON a.anime_id = pao.anime_id
         WHERE a.start_date BETWEEN #{startDate} AND #{endDate}
         AND a.status = 'NOT_YET_RELEASED'
-        ORDER BY pao.score DESC
+        ORDER BY a.popularity DESC
             LIMIT 30
     </select>
 

--- a/src/main/resources/mapper/anime/AnimeQueryMapper.xml
+++ b/src/main/resources/mapper/anime/AnimeQueryMapper.xml
@@ -74,11 +74,9 @@
                a.cover_image_url AS coverImageUrl,
                a.start_date AS startDate,
                a.format AS format,
-               pao.score AS score,
+               a.popularity AS score,
                a.is_adult AS isAdult
         FROM Anime a
-        JOIN PopularityAnimeOrder pao
-        ON pao.anime_id = a.anime_id
         WHERE
          <if test="includeAdult != true">
             a.is_adult = #{includeAdult}
@@ -87,7 +85,7 @@
             a.status = 'NOT_YET_RELEASED'
         AND a.cover_image_url != #{defaultCoverUrl}
         <if test="lastId != null">
-            AND pao.score &lt; #{lastId}
+            AND a.popularity &lt; #{lastId}
         </if>
         ORDER BY ${orderByQuery}
         LIMIT #{size}

--- a/src/main/resources/mapper/explore/ExploreQueryMapper.xml
+++ b/src/main/resources/mapper/explore/ExploreQueryMapper.xml
@@ -23,19 +23,23 @@
             resultType="long">
         SELECT COUNT(DISTINCT a.anime_id)
         FROM Anime a
+        <where>
+            <include refid="commonFilters"/>
             <if test="genresSize > 0">
-            <choose>
-            <!-- 옵션 OR 일 경우 -->
-                <when test="genreOp == 'OR'">
-                    JOIN AnimeGenres ag ON ag.anime_id = a.anime_id
-                    AND ag.genre_id IN
-                    <foreach item="g" collection="genres" open="(" separator="," close=")">
-                        #{g}
-                    </foreach>
-                </when>
-            <!-- 옵션 AND 일 경우 -->
-                <otherwise>
-                    JOIN (
+                <choose>
+                    <when test="genreOp == 'OR'">
+                        AND EXISTS (
+                        SELECT 1
+                        FROM AnimeGenres ag
+                        WHERE ag.anime_id = a.anime_id
+                        AND ag.genre_id IN
+                        <foreach item="g" collection="genres" open="(" separator="," close=")">
+                            #{g}
+                        </foreach>
+                        )
+                    </when>
+                    <otherwise>
+                        AND a.anime_id IN (
                         SELECT anime_id
                         FROM AnimeGenres
                         WHERE genre_id IN
@@ -44,12 +48,10 @@
                         </foreach>
                         GROUP BY anime_id
                         HAVING COUNT(DISTINCT genre_id) = #{genresSize}
-                    ) ag2 ON ag2.anime_id = a.anime_id
-                </otherwise>
-            </choose>
-        </if>
-        <where>
-            <include refid="commonFilters"/>
+                        )
+                    </otherwise>
+                </choose>
+            </if>
         </where>
     </select>
 
@@ -64,75 +66,71 @@
         a.title_romaj AS titleRom,
         a.title_native AS titleNat,
         a.cover_image_url AS coverImageUrl,
-        a.review_average_score   AS averageScore,
-        pao.score AS score
+        a.review_average_score AS averageScore,
+        a.popularity AS score
         FROM Anime a
+        <where>
+            <!-- 공통 필터 -->
+            <include refid="commonFilters"/>
 
-        <!-- 장르 필터링 -->
-        <if test="genres != null and genres.size() &gt; 0">
-            <choose>
-                <!-- 옵션 OR 일 경우 -->
-                <when test="genreOp == 'OR'">
-                    JOIN (
-                    SELECT DISTINCT anime_id
-                    FROM AnimeGenres
-                    WHERE genre_id IN
-                    <foreach item="g" collection="genres" open="(" separator="," close=")">
-                        #{g}
-                    </foreach>
-                    ) ag2 ON ag2.anime_id = a.anime_id
-                </when>
-                <!-- 옵션 AND 일 경우 -->
-                <otherwise>
-                    JOIN (
-                    SELECT anime_id
-                    FROM AnimeGenres
-                    WHERE genre_id IN
-                    <foreach item="g" collection="genres" open="(" separator="," close=")">
-                        #{g}
-                    </foreach>
-                    GROUP BY anime_id
-                    HAVING COUNT(DISTINCT genre_id) = #{genresSize}
-                    ) ag2 ON ag2.anime_id = a.anime_id
-                </otherwise>
-            </choose>
-        </if>
+            <!-- 장르 필터 -->
+            <if test="genres != null and genres.size() &gt; 0">
+                <choose>
+                    <!-- 옵션 OR 일 경우 -->
+                    <when test="genreOp == 'OR'">
+                        AND EXISTS (
+                        SELECT 1
+                        FROM AnimeGenres ag
+                        WHERE ag.anime_id = a.anime_id
+                        AND ag.genre_id IN
+                        <foreach item="g" collection="genres" open="(" separator="," close=")">
+                            #{g}
+                        </foreach>
+                        )
+                    </when>
+                    <!-- 옵션 AND 일 경우 -->
+                    <otherwise>
+                        AND a.anime_id IN (
+                        SELECT anime_id
+                        FROM AnimeGenres
+                        WHERE genre_id IN
+                        <foreach item="g" collection="genres" open="(" separator="," close=")">
+                            #{g}
+                        </foreach>
+                        GROUP BY anime_id
+                        HAVING COUNT(DISTINCT genre_id) = #{genresSize}
+                        )
+                    </otherwise>
+                </choose>
+            </if>
 
-        <!-- 커서 / 정렬 조인 / 조건 -->
+            <!-- 커서 조건 -->
+            <if test="sort == 'popularity' and lastId != null">
+                AND a.popularity &lt; #{lastId}
+            </if>
+            <if test="sort != 'popularity' and lastId != null">
+                <choose>
+                    <when test="lastValue != null">
+                        AND (
+                        (a.review_average_score &lt; #{lastValue}) -- 낮은 평점
+                        OR (a.review_average_score = #{lastValue} AND a.anime_id &lt; #{lastId}) -- 동점 낮은 ID
+                        OR (a.review_average_score IS NULL) -- 평점 없는 데이터는 나중에
+                        )
+                    </when>
+                    <otherwise>
+                        AND a.review_average_score IS NULL
+                        AND a.anime_id &lt; #{lastId}
+                    </otherwise>
+                </choose>
+            </if>
+        </where>
+
+        <!-- 정렬 조건 -->
         <choose>
-            <!-- 인기순 -->
             <when test="sort == 'popularity'">
-                JOIN PopularityAnimeOrder pao
-                ON pao.anime_id = a.anime_id
-                <if test="lastId != null">
-                    AND pao.score &lt; #{lastId}
-                </if>
-                <where>1=1<include refid="commonFilters"/></where>
                 ORDER BY ${orderByQuery}
             </when>
-            <!-- 평점순 -->
             <otherwise>
-                LEFT JOIN PopularityAnimeOrder pao
-                ON pao.anime_id = a.anime_id
-                <where>
-                      <if test="lastId != null">
-                        <choose>
-                          <when test="lastValue != null">
-                            (
-                              a.review_average_score &lt; #{lastValue}
-                              OR
-                              (a.review_average_score = #{lastValue} AND a.anime_id &lt; #{lastId})
-                            )
-                          </when>
-                          <!-- ID만 있을 경우 -->
-                          <otherwise>
-                            a.review_average_score IS NULL
-                            AND a.anime_id &lt; #{lastId}
-                          </otherwise>
-                        </choose>
-                      </if>
-                  <include refid="commonFilters"/>
-                </where>
                 ORDER BY ${orderByQuery}, a.anime_id DESC
             </otherwise>
         </choose>


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- `PopularityAnimeOrder` 테이블 삭제
- `Anime` 테이블의 `popularity` 값으로 대체함. popularity도 배치로 업데이트 하기 때문에...

---

**work-details**

- 쿼리, 코드 상 인기순(pao 테이블 -> anime.popularity) 코드 변경
- 탐색 매퍼 xml 정리 및 쿼리 변경

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
