### PR TITLE
fix/성우가 참여한 캐릭터 수 쿼리 변경

### DIFF
--- a/src/main/java/com/anipick/backend/person/controller/PersonController.java
+++ b/src/main/java/com/anipick/backend/person/controller/PersonController.java
@@ -17,10 +17,10 @@ public class PersonController {
 
     @GetMapping("/{personId}")
     public ApiResponse<PersonDetailPageDto> getAnimeAndCharacterOfPerson(
-            @PathVariable(value = "personId") Long personId,
-            @AuthenticationPrincipal CustomUserDetails user,
-            @RequestParam(required = false) Long lastId,
-            @RequestParam(defaultValue = "18") int size
+        @PathVariable(value = "personId") Long personId,
+        @RequestParam(value = "lastId", required = false) Long lastId,
+        @RequestParam(value = "size", defaultValue = "18") int size,
+        @AuthenticationPrincipal CustomUserDetails user
     ) {
         Long userId = user.getUserId();
         PersonDetailPageDto result = personService.getAnimeAndCharacter(personId, lastId, size, userId);

--- a/src/main/resources/mapper/person/PersonQueryMapper.xml
+++ b/src/main/resources/mapper/person/PersonQueryMapper.xml
@@ -17,9 +17,11 @@
     </select>
 
     <select id="countAnimesByActor" resultType="long">
-        SELECT COUNT(*)
+        SELECT count(*)
         FROM voiceactorcharacter vc
-        WHERE vc.voiceactor_id = #{personId}
+                 JOIN `character` c on vc.character_id = c.character_id
+                 JOIN characteranime ca on ca.character_id = c.character_id
+        WHERE voiceactor_id = #{personId}
     </select>
 
     <select id="selectWorksByActor" resultType="com.anipick.backend.person.dto.PersonAnimeWorkAllTitleAndNameDto">


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 기존에는 `voiceactorcharacter` 테이블에서만 성우 ID 값으로만 COUNT 했음.
- `같은` 캐릭터가 다른 애니(1기, 2기, 극장판..)에서도 나올 수 있기 때문에 `characteranime` 관계 테이블 JOIN 추가

---

**work-details**

- 성우가 참여한 캐릭터(애니) 카운트 쿼리에 JOIN 테이블 추가

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
