### PR TITLE
fix/회원가입 시 애니평가의 애니조회 쿼리 수정

### DIFF
--- a/src/main/resources/mapper/explore/UserSignUpAnimeQueryMapper.xml
+++ b/src/main/resources/mapper/explore/UserSignUpAnimeQueryMapper.xml
@@ -53,18 +53,15 @@
      <select id="selectAnimeExploredAndSearch"
           parameterType="com.anipick.backend.explore.dto.SignUpAnimeExploreSearchRequestDto"
           resultType="com.anipick.backend.explore.dto.SignUpPopularAnimeAllTitleItemDto">
-         SELECT pa.score AS score,
+         SELECT a.popularity AS score,
                 a.anime_id AS animeId,
                 a.title_kor AS titleKor,
                 a.title_english AS titleEng,
                 a.title_romaj AS titleRom,
                 a.title_native AS titleNat,
                 a.cover_image_url AS coverImageUrl
-         FROM popularityanimeorder pa
-            JOIN anime a
-                ON pa.anime_id = a.anime_id
+         FROM Anime a
          <where>
-             pa.created_at = #{nowString}
              <!-- 검색 -->
              <if test="query != null and query.trim() != ''">
                  AND a.title_search LIKE CONCAT('%', #{query}, '%')
@@ -87,11 +84,11 @@
 
              <!-- 커서 -->
              <if test="lastId != null">
-                 AND pa.score &lt; #{lastId}
+                 AND a.popularity &lt; #{lastId}
              </if>
          </where>
 
-         ORDER BY pa.score DESC
+         ORDER BY a.popularity DESC
          LIMIT #{size}
   </select>
 


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- `PopularOrderAnime` 테이블을 더이상 사용하지 않음에 따라 쿼리 변경

---

**work-details**

https://github.com/Anipick-Team/anipick-backend/pull/263 에서 처리했어야 했는데, 해당 기능을 생각지 못했습니다...

- 회원가입 시 애니평가의 애니조회 쿼리 수정

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test

