### PR TITLE
fix/성우 참여한 캐릭터&작품 리스트 페이징 수정

### DIFF
--- a/src/main/java/com/anipick/backend/person/dto/PersonAnimeWorkAllTitleAndNameDto.java
+++ b/src/main/java/com/anipick/backend/person/dto/PersonAnimeWorkAllTitleAndNameDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public class PersonAnimeWorkAllTitleAndNameDto {
     private Long animeId;
+    private Long popularity;
     private String animeTitleKor;
     private String animeTitleEng;
     private String animeTitleRom;

--- a/src/main/java/com/anipick/backend/person/service/PersonService.java
+++ b/src/main/java/com/anipick/backend/person/service/PersonService.java
@@ -25,7 +25,9 @@ public class PersonService {
 
         long totalCount = personMapper.countAnimesByActor(personId);
 
-        List<PersonAnimeWorkDto> items = personMapper.selectWorksByActor(personId, lastId, size)
+        List<PersonAnimeWorkAllTitleAndNameDto> items = personMapper.selectWorksByActor(personId, lastId, size);
+
+        List<PersonAnimeWorkDto> animeTitlePickItems = items
                 .stream()
                 .map(PersonAnimeWorkDto::animeTitleAndCharacterNameTranslationPick)
                 .toList();
@@ -34,7 +36,7 @@ public class PersonService {
         if (items.isEmpty()) {
             nextId = null;
         } else {
-            nextId = items.getLast().getAnimeId();
+            nextId = items.getLast().getPopularity();
         }
         CursorDto cursor = CursorDto.of(nextId);
 
@@ -45,7 +47,7 @@ public class PersonService {
                 personInfoDto.getIsLiked(),
                 totalCount,
                 cursor,
-                items
+                animeTitlePickItems
         );
     }
 }

--- a/src/main/resources/mapper/person/PersonQueryMapper.xml
+++ b/src/main/resources/mapper/person/PersonQueryMapper.xml
@@ -28,6 +28,7 @@
 
     <select id="selectWorksByActor" resultType="com.anipick.backend.person.dto.PersonAnimeWorkAllTitleAndNameDto">
         SELECT a.anime_id AS animeId,
+               a.popularity AS popularity,
                a.title_kor AS animeTitleKor,
                a.title_english AS animeTitleEng,
                a.title_romaj AS animeTitleRom,


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 기존에는 popularity 로 정렬하고, animeId 로 페이징(lastId)를 넘겼습니다.
- 그래서 데이터의 중복이 발생했습니다.


---

**work-details**

- popularity 값으로 lastId를 처리하도록 변경

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

<img width="1922" height="336" alt="image" src="https://github.com/user-attachments/assets/4ce12903-9402-4e49-87b8-c29868331283" />


### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
