### PR TITLE
fix/탈퇴한 사용자 30일 내에 동일한 이메일로 재가입 시 예외 처리

### DIFF
--- a/src/main/java/com/anipick/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/anipick/backend/common/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
 	USER_ANIME_OF_STATUS_DATA_NOT_FOUND(129, "유저 시청상태 데이터 찾을 수 없음", null),
 	ALREADY_BLOCKED_USER(130, "이미 차단한 유저", null),
 	SELF_BLOCKED_USER_ERROR(131, "본인 자신은 차단 불가", null),
+    ALREADY_DELETED_ACCOUNT_BEFORE_30DAYS(132, "30일 이전에 삭제된 계정", "계정 탈퇴 후 30일 동안 동일한 이메일로 재가입할 수 없습니다."),
 	/**
 	 * Review
 	 */

--- a/src/main/java/com/anipick/backend/user/service/UserService.java
+++ b/src/main/java/com/anipick/backend/user/service/UserService.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +38,17 @@ public class UserService {
     public SignUpResponse signUp(SignUpRequest request) {
         String requestEmail = request.getEmail();
         String requestPassword = request.getPassword();
+
+        // 30일 내에 탈퇴한 회원인지 확인
+        Optional<User> optionalUser = userMapper.findByEmail(requestEmail);
+        if(optionalUser.isPresent()) {
+            User user = optionalUser.get();
+            LocalDateTime deletedAt = user.getDeletedAt();
+
+            if(deletedAt != null) {
+                throw new CustomException(ErrorCode.ALREADY_DELETED_ACCOUNT_BEFORE_30DAYS);
+            }
+        }
 
         // 이메일 중복 확인
         if(checkDuplicateEmail(requestEmail)) {

--- a/src/main/resources/mapper/user/UserCommandMapper.xml
+++ b/src/main/resources/mapper/user/UserCommandMapper.xml
@@ -39,7 +39,6 @@
         UPDATE User
         SET nickname = #{nickname},
             password = '',
-            login_format = '',
             deleted_at = NOW()
         WHERE user_id = #{userId}
     </update>


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->
* 탈퇴한 사용자가 30일 이내에 동일한 이메일로 재가입 시 500 에러가 발생했었습니다.
* 따라서 이에 대한 예외 처리(예외 코드)를 하여 앱 프론트에게 전달합니다.

---

**work-details**

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->
<img width="977" height="886" alt="image" src="https://github.com/user-attachments/assets/7a9a68ec-87af-4365-8391-c4d76132b978" />


### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
