### PR TITLE
fix/리뷰 개수 값이 0일 때 if문 분기 나누기 처리

### DIFF
--- a/src/main/java/com/anipick/backend/review/service/ReviewService.java
+++ b/src/main/java/com/anipick/backend/review/service/ReviewService.java
@@ -1,5 +1,6 @@
 package com.anipick.backend.review.service;
 
+import com.anipick.backend.anime.domain.Anime;
 import com.anipick.backend.anime.mapper.AnimeMapper;
 import com.anipick.backend.common.dto.CursorDto;
 import com.anipick.backend.common.exception.CustomException;
@@ -173,6 +174,8 @@ public class ReviewService {
 
         Long animeId = review.getAnimeId();
 
+        Anime anime = animeMapper.selectAnimeByAnimeId(animeId);
+
         RLock lock = redissonClient.getLock("anime:" + animeId + ":lock");
         boolean isLocked = false;
 
@@ -182,7 +185,9 @@ public class ReviewService {
                 log.error("락 획득 실패");
                 throw new CustomException(ErrorCode.GET_LOCK_FAILED);
             }
-            animeMapper.updateMinusReviewCount(animeId);
+            if (anime.getReviewCount() > 0) {
+                animeMapper.updateMinusReviewCount(animeId);
+            }
             reviewMapper.deleteReview(reviewId, userId);
 
             List<Review> reviewsByAnimeId = reviewMapper.findAllByAnimeId(animeId);


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 리뷰 개수(반정규화 컬럼) 값이 0일 때 리뷰 삭제 시 음수가 되는 상황

---

**work-details**

- 삭제 시 리뷰 개수 값 확인 후 0 초과일 경우만 minus 처리

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
