### PR TITLE
fix/로그인 실패 시 106 -> 101번으로 에러 코드 변경

### DIFF
--- a/src/main/java/com/anipick/backend/user/service/UserService.java
+++ b/src/main/java/com/anipick/backend/user/service/UserService.java
@@ -91,7 +91,7 @@ public class UserService {
                 .orElseThrow(() -> new CustomException(ErrorCode.ACCOUNT_NOT_FOUND_BY_EMAIL));
 
         if(!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new CustomException(ErrorCode.LOGIN_PASSWORD_MISMATCH);
+            throw new CustomException(ErrorCode.LOGIN_FAIL);
         }
 
         TokenResponse response = tokenService.generateAndSaveTokens(user.getEmail());


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->
* 현재 로그인 실패 시 106번으로 에러 코드를 반환하고 있습니다.
* 106번으로 에러 코드 반환 시 비밀번호 불일치로 인한 원인으로 로그인이 안된다는 것을 사용자가 인지 가능하기에
* 보안적인 이슈로 101번으로 변경합니다.

---

**work-details**

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->
<img width="994" height="693" alt="image" src="https://github.com/user-attachments/assets/94633969-4cdf-4417-8d21-cac350cc5863" />


### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test
