### PR TITLE
fix/TAG_BASED 상태일 때 리뷰가 없는 경우 바로 리턴

### DIFF
--- a/src/main/java/com/anipick/backend/home/service/HomeService.java
+++ b/src/main/java/com/anipick/backend/home/service/HomeService.java
@@ -158,6 +158,11 @@ public class HomeService {
         } else {
             List<Long> topRatedAnimeIds = reviewUserMapper.findTopRatedAnimeIds(userId, 20);
 
+            // 리뷰가 없는 경우 바로 리턴한다.
+            if (topRatedAnimeIds.isEmpty()) {
+                    return HomeRecommendationItemDto.of(null, List.of());
+            }
+
             List<Long> filteredIds = topRatedAnimeIds.stream()
                     .filter(topRatedAnimeIds::contains)
                     .toList();


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 기존에는 홈 기능에서 TAG_BASED 상태일 때 리뷰가 없는 경우 오류가 나타났습니다.
- https://github.com/Anipick-Team/anipick-backend/issues/355 에서 오류 상세 확인 가능합니다.

---

**work-details**

- `TAG_BASED` 상태이면서 리뷰가 없을 경우, 아이템의 개수가 0인 상태로 바로 리턴합니다.

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
