### PR TITLE
fix/referenceAnimeTitle 유저 추천 상태에 따라 값 변경

### DIFF
--- a/src/main/java/com/anipick/backend/home/service/HomeService.java
+++ b/src/main/java/com/anipick/backend/home/service/HomeService.java
@@ -135,9 +135,14 @@ public class HomeService {
         }
 
         List<AnimeItemDto> resultAnimes;
+        String referenceAnimeTitle;
 
         if (userState.getMode() == UserRecommendMode.RECENT_HIGH) {
             Long referenceAnimeId = reviewUserMapper.findMostRecentHighRateAnime(userId);
+
+            Anime anime = animeMapper.selectAnimeByAnimeId(referenceAnimeId);
+            referenceAnimeTitle = anime.getTitlePick();
+
             List<Long> tagIds = animeTagMapper.findTopTagsByAnime(referenceAnimeId, 5);
 
             RecentHighCountOnlyRequest request =
@@ -156,6 +161,8 @@ public class HomeService {
                     ))
                     .toList();
         } else {
+            referenceAnimeTitle = null;
+
             List<Long> topRatedAnimeIds = reviewUserMapper.findTopRatedAnimeIds(userId, 20);
 
             // 리뷰가 없는 경우 바로 리턴한다.
@@ -191,7 +198,7 @@ public class HomeService {
                     ))
                     .toList();
         }
-        return HomeRecommendationItemDto.of(null, resultAnimes);
+        return HomeRecommendationItemDto.of(referenceAnimeTitle, resultAnimes);
     }
 
     public HomeRecommendationItemDto getLastDetailAnimeRecommendations(Long userId, Long animeId) {


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 기존 코드는 return에 `null` 값으로 넣어 추천 상태에 `referenceAnimeTitle` 의 값이 따라 바뀌지 않았음. 항상 `null`

---


**work-details**


- 유저 상태에 따라 `referenceAnimeTitle` 값이 바뀌도록
  - `RECENT_HIGH` : referenceAnimeTitle 값 추가
  - `TAG_BASED` : null 처리 (기준 애니가 아니기 때문)

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
