### PR TITLE
fix/홈 - 추천2에서 첫 방문 시 빈값 처리

### DIFF
--- a/src/main/java/com/anipick/backend/home/service/HomeService.java
+++ b/src/main/java/com/anipick/backend/home/service/HomeService.java
@@ -203,6 +203,11 @@ public class HomeService {
 
     public HomeRecommendationItemDto getLastDetailAnimeRecommendations(Long userId, Long animeId) {
         Anime anime = animeMapper.selectAnimeByAnimeId(animeId);
+        // 첫 방문 시 anime는 null이기 때문에 빈 값 처리
+        if (anime == null) {
+            return HomeRecommendationItemDto.of(null, List.of());
+        }
+
         String referenceAnimeTitle = anime.getTitlePick();
 
         List<AnimeItemDto> resultAnimes;


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 기존에 추천 2에서 첫 방문 시(animeId 파라미터 null) 

```
java.lang.NullPointerException: Cannot invoke "com.anipick.backend.anime.domain.Anime.getTitlePick()" because "anime" is null
	at com.anipick.backend.home.service.HomeService.getLastDetailAnimeRecommendations(HomeService.java:206)
	at com.anipick.backend.home.controller.HomeController.getHomeRecommendationLastDetailAnimes(HomeController.java:66)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
```

---

**work-details**

- anime 가 null 일 경우 빈값 호출 처리

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
