### PR TITLE
feat/정적 리소스 파일 캐싱 처리

### DIFF
--- a/src/main/java/com/anipick/backend/common/config/WebConfig.java
+++ b/src/main/java/com/anipick/backend/common/config/WebConfig.java
@@ -2,8 +2,11 @@ package com.anipick.backend.common.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -14,5 +17,9 @@ public class WebConfig implements WebMvcConfigurer {
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/images/profile/**")
                 .addResourceLocations("file:" + uploadDir);
+
+        registry.addResourceHandler("/static/**")
+                .addResourceLocations("classpath:/static/")
+                .setCacheControl(CacheControl.maxAge(365, TimeUnit.DAYS).cachePublic());
     }
 }


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 기존에는 캐싱처리가 되지 않아, 소개 페이지 진입 시 항상 로드함

---

**work-details**

- 정적파일의 변동이 거의 없을 것이라 생각해, Java Config 단에서 캐싱처리(1년)했습니다.
  - 변경사항이 조금 생길 것 같다면 기간을 줄여도 좋습니다.
  - 추후에 파일을 변경할 때는 이미 캐시된 자원으로 계속 나올 경우, 버전 전략을 통해 변경하고자 합니다.

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test
