### PR TITLE
fix/레디스에 주간 검색 데이터가 없는 경우 빈값 리턴

### DIFF
--- a/src/main/java/com/anipick/backend/search/dto/SearchInitPageDto.java
+++ b/src/main/java/com/anipick/backend/search/dto/SearchInitPageDto.java
@@ -10,4 +10,8 @@ import java.util.List;
 @AllArgsConstructor
 public class SearchInitPageDto {
     private List<AnimeItemDto> popularAnimes;
+
+    public static SearchInitPageDto of(List<AnimeItemDto> dto) {
+        return new SearchInitPageDto(dto);
+    }
 }

--- a/src/main/java/com/anipick/backend/search/service/SearchService.java
+++ b/src/main/java/com/anipick/backend/search/service/SearchService.java
@@ -40,13 +40,17 @@ public class SearchService {
 			JsonNode jsonNode = objectMapper.readTree(redisWeekBestAnimeIdsJsonStr);
 			List<Long> searchBestAnimeIds = objectMapper
 				.convertValue(jsonNode.get("search_anime_id"), new TypeReference<>() {});
+			// 레디스에 주간 검색 데이터가 하나도 없는 경우
+			if (searchBestAnimeIds.isEmpty()) {
+				return SearchInitPageDto.of(List.of());
+			}
 
 			List<AnimeItemDto> items = mapper.selectSearchWeekBestAnimes(searchBestAnimeIds)
 				.stream()
 				.map(AnimeItemDto::animeTitleTranslationPick)
 				.toList();
 
-			return new SearchInitPageDto(items);
+			return SearchInitPageDto.of(items);
 
 		} catch (JsonProcessingException e) {
 			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 레디스에 주간 검색 애니 값이 하나도 없을 경우 쿼리 in절에 파라미터가 빈값으로 들어가, 쿼리 오류 발생

---

**work-details**

- 레디스에 주간 검색 애니 ID 값이 없을 경우(`isEmpty`) 빈값으로 바로 리턴 처리
```json
{
    "code": 200,
    "value": "success",
    "result": {
        "popularAnimes": []
    }
}
```

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
