### PR TITLE
feat/어드민에서 수동 번역 데이터 추가한 값으로 먼저 보여주기

### DIFF
--- a/src/main/java/com/anipick/backend/anime/domain/Anime.java
+++ b/src/main/java/com/anipick/backend/anime/domain/Anime.java
@@ -14,12 +14,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Anime {
 	private Long animeId;
+	private String titleMan;
 	private String titleKor;
 	private String titleEng;
 	private String titleRom;
 	private String titleNat;
 	private String coverImageUrl;
 	private String bannerImageUrl;
+	private String descriptionMan;
 	private String descriptionKor;
 	private LocalDate startDate;
 	private LocalDate endDate;
@@ -42,10 +44,18 @@ public class Anime {
 
 	public String getTitlePick() {
 		return LocalizationUtil.pickTitle(
+				this.getTitleMan(),
                 this.getTitleKor(),
                 this.getTitleEng(),
                 this.getTitleRom(),
                 this.getTitleNat()
         );
+	}
+
+	public String getDescriptionPick() {
+		return LocalizationUtil.pickDescription(
+				this.getDescriptionMan(),
+				this.getDescriptionKor()
+		);
 	}
 }

--- a/src/main/java/com/anipick/backend/anime/dto/AnimeAllTitleDateDto.java
+++ b/src/main/java/com/anipick/backend/anime/dto/AnimeAllTitleDateDto.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 @Getter
 public class AnimeAllTitleDateDto {
     private Long animeId;
+    private String titleMan;
     private String titleKor;
 	private String titleEng;
 	private String titleRom;

--- a/src/main/java/com/anipick/backend/anime/dto/AnimeAllTitleImgDto.java
+++ b/src/main/java/com/anipick/backend/anime/dto/AnimeAllTitleImgDto.java
@@ -11,6 +11,7 @@ public class AnimeAllTitleImgDto implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private Long animeId;
+	private String titleMan;
 	private String titleKor;
 	private String titleEng;
 	private String titleRom;

--- a/src/main/java/com/anipick/backend/anime/dto/AnimeDateItemDto.java
+++ b/src/main/java/com/anipick/backend/anime/dto/AnimeDateItemDto.java
@@ -16,6 +16,7 @@ public class AnimeDateItemDto {
 
     public static AnimeDateItemDto animeTitleTranslationPick(AnimeAllTitleDateDto dto) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
 				dto.getTitleKor(),
 				dto.getTitleEng(),
 				dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/anime/dto/AnimeDetailInfoItemDto.java
+++ b/src/main/java/com/anipick/backend/anime/dto/AnimeDetailInfoItemDto.java
@@ -9,13 +9,15 @@ import java.time.LocalDate;
 @Getter
 public class AnimeDetailInfoItemDto {
     private Long animeId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;
     private String titleNat;
     private String coverImageUrl;
     private String bannerImageUrl;
-    private String description;
+    private String descriptionMan;
+    private String descriptionKor;
     private Double averageRating;
     private Boolean isLiked;
     private UserAnimeOfStatus watchStatus;

--- a/src/main/java/com/anipick/backend/anime/dto/AnimeItemDto.java
+++ b/src/main/java/com/anipick/backend/anime/dto/AnimeItemDto.java
@@ -13,6 +13,7 @@ public class AnimeItemDto {
 
 	public static AnimeItemDto animeTitleTranslationPick(AnimeAllTitleImgDto dto) {
 		String title = LocalizationUtil.pickTitle(
+				dto.getTitleMan(),
 				dto.getTitleKor(),
 				dto.getTitleEng(),
 				dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/anime/dto/ComingSoonItemAllTitleDto.java
+++ b/src/main/java/com/anipick/backend/anime/dto/ComingSoonItemAllTitleDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ComingSoonItemAllTitleDto {
     private Long animeId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/anime/dto/ComingSoonItemBasicDto.java
+++ b/src/main/java/com/anipick/backend/anime/dto/ComingSoonItemBasicDto.java
@@ -24,6 +24,7 @@ public class ComingSoonItemBasicDto {
 
     public static ComingSoonItemBasicDto animeTitleTranslationPick(ComingSoonItemAllTitleDto dto) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
                 dto.getTitleKor(),
                 dto.getTitleEng(),
                 dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/anime/dto/ComingSoonItemPopularityAlltitleDto.java
+++ b/src/main/java/com/anipick/backend/anime/dto/ComingSoonItemPopularityAlltitleDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ComingSoonItemPopularityAlltitleDto {
     private Long animeId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/anime/dto/ComingSoonItemPopularityDto.java
+++ b/src/main/java/com/anipick/backend/anime/dto/ComingSoonItemPopularityDto.java
@@ -25,6 +25,7 @@ public class ComingSoonItemPopularityDto {
 
     public static ComingSoonItemPopularityDto animeTitleTranslationPick(ComingSoonItemPopularityAlltitleDto dto) {
         String finalTitle = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
                 dto.getTitleKor(),
                 dto.getTitleEng(),
                 dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/anime/service/AnimeService.java
+++ b/src/main/java/com/anipick/backend/anime/service/AnimeService.java
@@ -209,10 +209,16 @@ public class AnimeService {
                 .toList();
 
         String pickTitle = LocalizationUtil.pickTitle(
+                animeDetailInfoItemDto.getTitleMan(),
                 animeDetailInfoItemDto.getTitleKor(),
                 animeDetailInfoItemDto.getTitleEng(),
                 animeDetailInfoItemDto.getTitleRom(),
                 animeDetailInfoItemDto.getTitleNat()
+        );
+
+        String pickDescription = LocalizationUtil.pickDescription(
+                animeDetailInfoItemDto.getDescriptionMan(),
+                animeDetailInfoItemDto.getDescriptionKor()
         );
 
         return AnimeDetailInfoResultDto.builder()
@@ -220,7 +226,7 @@ public class AnimeService {
                 .title(pickTitle)
                 .coverImageUrl(animeDetailInfoItemDto.getCoverImageUrl())
                 .bannerImageUrl(animeDetailInfoItemDto.getBannerImageUrl())
-                .description(animeDetailInfoItemDto.getDescription())
+                .description(pickDescription)
                 .averageRating(animeDetailInfoItemDto.getAverageRatingAsString())
                 .isLiked(animeDetailInfoItemDto.getIsLiked())
                 .watchStatus(animeDetailInfoItemDto.getWatchStatus())

--- a/src/main/java/com/anipick/backend/common/util/LocalizationUtil.java
+++ b/src/main/java/com/anipick/backend/common/util/LocalizationUtil.java
@@ -2,13 +2,17 @@ package com.anipick.backend.common.util;
 
 public class LocalizationUtil {
     /**
+     * @param manualTitle 수동 번역
      * @param korTitle 번역
      * @param engTitle 영어
      * @param romajTitle 로마자
      * @param nativeTitle 원어
-     * @return 우선순위 번역-영어-로마자-원어 (전부 null일 경우, "제목 정보 없음" 리턴)
+     * @return 우선순위 매뉴얼 수동 번역 - 번역(kor)-영어-로마자-원어 (전부 null일 경우, "제목 정보 없음" 리턴)
      */
-    public static String pickTitle(String korTitle, String engTitle, String romajTitle, String nativeTitle) {
+    public static String pickTitle(String manualTitle, String korTitle, String engTitle, String romajTitle, String nativeTitle) {
+        if (manualTitle != null && !manualTitle.isBlank()) {
+            return manualTitle;
+        }
         if (korTitle != null && !korTitle.isBlank()) {
             return korTitle;
         }
@@ -22,6 +26,24 @@ public class LocalizationUtil {
             return nativeTitle;
         }
         return "제목 정보 없음";
+    }
+
+    /**
+     *
+     * @param descriptionManual
+     * @param descriptionKor
+     * @return
+     */
+    public static String pickDescription(String descriptionManual, String descriptionKor) {
+        if (descriptionManual != null && !descriptionManual.isBlank()) {
+            return descriptionManual;
+        }
+
+        if (descriptionKor != null && !descriptionKor.isBlank()) {
+            return descriptionKor;
+        }
+
+        return "소개 정보 없음";
     }
 
     /**

--- a/src/main/java/com/anipick/backend/common/util/LocalizationUtil.java
+++ b/src/main/java/com/anipick/backend/common/util/LocalizationUtil.java
@@ -43,7 +43,7 @@ public class LocalizationUtil {
             return descriptionKor;
         }
 
-        return "소개 정보 없음";
+        return "줄거리 정보 없음";
     }
 
     /**

--- a/src/main/java/com/anipick/backend/explore/dto/ExploreAllTitleItemDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/ExploreAllTitleItemDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ExploreAllTitleItemDto {
     private Long id;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/explore/dto/ExploreItemDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/ExploreItemDto.java
@@ -15,6 +15,7 @@ public class ExploreItemDto {
 
     public static ExploreItemDto animeTitleTranslationPick(ExploreAllTitleItemDto dto) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
                 dto.getTitleKor(),
                 dto.getTitleEng(),
                 dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/explore/dto/SignUpPopularAnimeAllTitleItemDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/SignUpPopularAnimeAllTitleItemDto.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class SignUpPopularAnimeAllTitleItemDto {
     private Long animeId;
     private Long score;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/explore/dto/SignUpPopularAnimeItemDto.java
+++ b/src/main/java/com/anipick/backend/explore/dto/SignUpPopularAnimeItemDto.java
@@ -19,6 +19,7 @@ public class SignUpPopularAnimeItemDto  {
 
     public static SignUpPopularAnimeItemDto animeTitleTranslationPick(SignUpPopularAnimeAllTitleItemDto dto) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
                 dto.getTitleKor(),
                 dto.getTitleEng(),
                 dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/home/dto/HomeRecentReviewAnimeAllTitleItemDto.java
+++ b/src/main/java/com/anipick/backend/home/dto/HomeRecentReviewAnimeAllTitleItemDto.java
@@ -9,6 +9,7 @@ public class HomeRecentReviewAnimeAllTitleItemDto {
     private Long reviewId;
     private Long userId;
     private Long animeId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/home/dto/HomeRecentReviewItemDto.java
+++ b/src/main/java/com/anipick/backend/home/dto/HomeRecentReviewItemDto.java
@@ -17,6 +17,7 @@ public class HomeRecentReviewItemDto {
 
     public static HomeRecentReviewItemDto animeTitleTranslationPick(HomeRecentReviewAnimeAllTitleItemDto dto) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
                 dto.getTitleKor(),
                 dto.getTitleEng(),
                 dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/home/dto/HomeTrendingRankingDto.java
+++ b/src/main/java/com/anipick/backend/home/dto/HomeTrendingRankingDto.java
@@ -13,7 +13,7 @@ public class HomeTrendingRankingDto {
     private String coverImageUrl;
 
     public static HomeTrendingRankingDto of(TrendingRankingFromQueryDto dto, Long rank) {
-        String title = LocalizationUtil.pickTitle(dto.getTitleKor(), dto.getTitleEng(), dto.getTitleRom(), dto.getTitleNat());
+        String title = LocalizationUtil.pickTitle(dto.getTitleMan(), dto.getTitleKor(), dto.getTitleEng(), dto.getTitleRom(), dto.getTitleNat());
 
         return new HomeTrendingRankingDto(
                 dto.getAnimeId(),

--- a/src/main/java/com/anipick/backend/home/dto/TrendingRankingFromQueryDto.java
+++ b/src/main/java/com/anipick/backend/home/dto/TrendingRankingFromQueryDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public class TrendingRankingFromQueryDto {
     private Long animeId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/mypage/dto/AnimesAllTitleReviewDto.java
+++ b/src/main/java/com/anipick/backend/mypage/dto/AnimesAllTitleReviewDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public class AnimesAllTitleReviewDto {
     private Long animeId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/mypage/dto/AnimesReviewDto.java
+++ b/src/main/java/com/anipick/backend/mypage/dto/AnimesReviewDto.java
@@ -19,6 +19,7 @@ public class AnimesReviewDto {
 
     public static AnimesReviewDto animeTitleTranslationPick(AnimesAllTitleReviewDto dto) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
 				dto.getTitleKor(),
 				dto.getTitleEng(),
 				dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/mypage/dto/FinishedAnimesAllTitleDto.java
+++ b/src/main/java/com/anipick/backend/mypage/dto/FinishedAnimesAllTitleDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public class FinishedAnimesAllTitleDto {
     private Long animeId;
     private Long userAnimeStatusId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/mypage/dto/FinishedAnimesDto.java
+++ b/src/main/java/com/anipick/backend/mypage/dto/FinishedAnimesDto.java
@@ -15,6 +15,7 @@ public class FinishedAnimesDto {
 
     public static FinishedAnimesDto animeTitleTranslationPick(FinishedAnimesAllTitleDto dto) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
 				dto.getTitleKor(),
 				dto.getTitleEng(),
 				dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/mypage/dto/LikedAnimesAllTitleDto.java
+++ b/src/main/java/com/anipick/backend/mypage/dto/LikedAnimesAllTitleDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public class LikedAnimesAllTitleDto {
     private Long animeId;
     private Long animeLikeId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/mypage/dto/LikedAnimesDto.java
+++ b/src/main/java/com/anipick/backend/mypage/dto/LikedAnimesDto.java
@@ -14,6 +14,7 @@ public class LikedAnimesDto {
 
     public static LikedAnimesDto animeTitleTranslationPick(LikedAnimesAllTitleDto dto) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
 				dto.getTitleKor(),
 				dto.getTitleEng(),
 				dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/mypage/dto/WatchListAnimesAllTitleDto.java
+++ b/src/main/java/com/anipick/backend/mypage/dto/WatchListAnimesAllTitleDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public class WatchListAnimesAllTitleDto {
     private Long animeId;
     private Long userAnimeStatusId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/mypage/dto/WatchListAnimesDto.java
+++ b/src/main/java/com/anipick/backend/mypage/dto/WatchListAnimesDto.java
@@ -14,6 +14,7 @@ public class WatchListAnimesDto {
 
     public static WatchListAnimesDto animeTitleTranslationPick(WatchListAnimesAllTitleDto dto) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
 				dto.getTitleKor(),
 				dto.getTitleEng(),
 				dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/mypage/dto/WatchingAnimesAllTitleDto.java
+++ b/src/main/java/com/anipick/backend/mypage/dto/WatchingAnimesAllTitleDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public class WatchingAnimesAllTitleDto {
     private Long animeId;
     private Long userAnimeStatusId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/mypage/dto/WatchingAnimesDto.java
+++ b/src/main/java/com/anipick/backend/mypage/dto/WatchingAnimesDto.java
@@ -14,6 +14,7 @@ public class WatchingAnimesDto {
 
     public static WatchingAnimesDto animeTitleTranslationPick(WatchingAnimesAllTitleDto dto) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
 				dto.getTitleKor(),
 				dto.getTitleEng(),
 				dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/person/dto/PersonAnimeWorkAllTitleAndNameDto.java
+++ b/src/main/java/com/anipick/backend/person/dto/PersonAnimeWorkAllTitleAndNameDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public class PersonAnimeWorkAllTitleAndNameDto {
     private Long animeId;
     private Long popularity;
+    private String animeTitleMan;
     private String animeTitleKor;
     private String animeTitleEng;
     private String animeTitleRom;

--- a/src/main/java/com/anipick/backend/person/dto/PersonAnimeWorkDto.java
+++ b/src/main/java/com/anipick/backend/person/dto/PersonAnimeWorkDto.java
@@ -15,6 +15,7 @@ public class PersonAnimeWorkDto {
 
     public static PersonAnimeWorkDto animeTitleAndCharacterNameTranslationPick(PersonAnimeWorkAllTitleAndNameDto dto) {
         String animeTitle = LocalizationUtil.pickTitle(
+                dto.getAnimeTitleMan(),
                 dto.getAnimeTitleKor(),
                 dto.getAnimeTitleEng(),
                 dto.getAnimeTitleRom(),

--- a/src/main/java/com/anipick/backend/ranking/dto/RankingAnimesDto.java
+++ b/src/main/java/com/anipick/backend/ranking/dto/RankingAnimesDto.java
@@ -19,6 +19,7 @@ public class RankingAnimesDto {
 
     public static RankingAnimesDto from(Long displayRank, RankingAnimesFromQueryDto dto, List<String> genres) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
                 dto.getTitleKor(),
                 dto.getTitleEng(),
                 dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/ranking/dto/RankingAnimesFromQueryDto.java
+++ b/src/main/java/com/anipick/backend/ranking/dto/RankingAnimesFromQueryDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class RankingAnimesFromQueryDto {
     private Long animeId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/ranking/dto/RealTimeRankingAnimesDto.java
+++ b/src/main/java/com/anipick/backend/ranking/dto/RealTimeRankingAnimesDto.java
@@ -21,6 +21,7 @@ public class RealTimeRankingAnimesDto {
 
     public static RealTimeRankingAnimesDto from(Long rank, String change, String trend, RealTimeRankingAnimesFromQueryDto dto, List<String> genres) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
                 dto.getTitleKor(),
                 dto.getTitleEng(),
                 dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/ranking/dto/RealTimeRankingAnimesFromQueryDto.java
+++ b/src/main/java/com/anipick/backend/ranking/dto/RealTimeRankingAnimesFromQueryDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 public class RealTimeRankingAnimesFromQueryDto {
     private Long animeId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/recommendation/dto/AnimeAllTitleItemRecommendTagCountDto.java
+++ b/src/main/java/com/anipick/backend/recommendation/dto/AnimeAllTitleItemRecommendTagCountDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class AnimeAllTitleItemRecommendTagCountDto {
     private Long animeId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/recommendation/dto/AnimeItemRecommendTagCountDto.java
+++ b/src/main/java/com/anipick/backend/recommendation/dto/AnimeItemRecommendTagCountDto.java
@@ -14,6 +14,7 @@ public class AnimeItemRecommendTagCountDto {
 
     public static AnimeItemRecommendTagCountDto animeTitleTranslationPick(AnimeAllTitleItemRecommendTagCountDto dto) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
                 dto.getTitleKor(),
                 dto.getTitleEng(),
                 dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/review/dto/RecentReviewItemAnimeAllTitleDto.java
+++ b/src/main/java/com/anipick/backend/review/dto/RecentReviewItemAnimeAllTitleDto.java
@@ -11,6 +11,7 @@ public class RecentReviewItemAnimeAllTitleDto {
     private Long reviewId;
     private Long userId;
     private Long animeId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/review/dto/RecentReviewItemDto.java
+++ b/src/main/java/com/anipick/backend/review/dto/RecentReviewItemDto.java
@@ -25,6 +25,7 @@ public class RecentReviewItemDto {
 
     public static RecentReviewItemDto animeTitleTranslationPick(RecentReviewItemAnimeAllTitleDto dto) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
 				dto.getTitleKor(),
 				dto.getTitleEng(),
 				dto.getTitleRom(),

--- a/src/main/java/com/anipick/backend/studio/dto/StudioAnimeAllTitleItemDto.java
+++ b/src/main/java/com/anipick/backend/studio/dto/StudioAnimeAllTitleItemDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public class StudioAnimeAllTitleItemDto {
     private Long animeId;
+    private String titleMan;
     private String titleKor;
     private String titleEng;
     private String titleRom;

--- a/src/main/java/com/anipick/backend/studio/dto/StudioAnimeItemDto.java
+++ b/src/main/java/com/anipick/backend/studio/dto/StudioAnimeItemDto.java
@@ -14,6 +14,7 @@ public class StudioAnimeItemDto {
 
     public static StudioAnimeItemDto animeTitleTranslationPick(StudioAnimeAllTitleItemDto dto) {
         String title = LocalizationUtil.pickTitle(
+                dto.getTitleMan(),
 				dto.getTitleKor(),
 				dto.getTitleEng(),
 				dto.getTitleRom(),

--- a/src/main/resources/mapper/anime/AnimeQueryMapper.xml
+++ b/src/main/resources/mapper/anime/AnimeQueryMapper.xml
@@ -8,6 +8,7 @@
             parameterType="com.anipick.backend.anime.dto.RangeDateRequestDto"
             resultType="com.anipick.backend.anime.dto.AnimeAllTitleImgDto">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,
@@ -40,6 +41,7 @@
             parameterType="com.anipick.backend.anime.dto.ComingSoonRequestDto"
             resultType="com.anipick.backend.anime.dto.ComingSoonItemAllTitleDto">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,
@@ -69,6 +71,7 @@
             parameterType="com.anipick.backend.anime.dto.ComingSoonRequestDto"
             resultType="com.anipick.backend.anime.dto.ComingSoonItemPopularityAlltitleDto">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,
@@ -99,6 +102,7 @@
             parameterType="com.anipick.backend.anime.dto.ComingSoonRequestDto"
             resultType="com.anipick.backend.anime.dto.ComingSoonItemAllTitleDto">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,
@@ -136,12 +140,14 @@
 
     <select id="selectAnimeByAnimeId" resultType="com.anipick.backend.anime.domain.Anime">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,
                a.title_native AS titleNat,
                a.cover_image_url AS coverImageUrl,
                a.banner_image_url AS bannerImageUrl,
+               a.description_kor_manual AS descriptionMan,
                a.description_kor AS descriptionKor,
                a.start_date AS startDate,
                a.end_date AS endDate,
@@ -252,13 +258,15 @@
 
     <select id="selectAnimeInfoDetail" resultType="com.anipick.backend.anime.dto.AnimeDetailInfoItemDto">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,
                a.title_native AS titleNat,
                a.cover_image_url AS coverImageUrl,
                a.banner_image_url AS bannerImageUrl,
-               a.description_kor AS description,
+               a.description_kor_manual AS descriptionMan,
+               a.description_kor AS descriptionKor,
                a.review_average_score AS averageRating,
                IF(ual.user_id IS NULL, FALSE, TRUE) AS isLiked,
                us.status AS watchStatus,
@@ -280,6 +288,7 @@
 
     <select id="selectAnimeInfoRecommendationsByAnimeId" resultType="com.anipick.backend.anime.dto.AnimeAllTitleImgDto">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,
@@ -303,6 +312,7 @@
 
     <select id="selectAnimeInfoSeriesByAnimeId" resultType="com.anipick.backend.anime.dto.AnimeAllTitleDateDto">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,
@@ -467,6 +477,7 @@
 
     <select id="selectRecommendationsByAnimeId" resultType="com.anipick.backend.anime.dto.AnimeAllTitleImgDto">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,
@@ -502,6 +513,7 @@
 
     <select id="selectSeriesByAnimeId" resultType="com.anipick.backend.anime.dto.AnimeAllTitleDateDto">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,

--- a/src/main/resources/mapper/anime/StudioQueryMapper.xml
+++ b/src/main/resources/mapper/anime/StudioQueryMapper.xml
@@ -22,6 +22,7 @@
 
     <select id="selectAnimesOfStudio" resultType="com.anipick.backend.studio.dto.StudioAnimeAllTitleItemDto">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,

--- a/src/main/resources/mapper/explore/ExploreQueryMapper.xml
+++ b/src/main/resources/mapper/explore/ExploreQueryMapper.xml
@@ -68,6 +68,7 @@
             resultType="com.anipick.backend.explore.dto.ExploreAllTitleItemDto">
         SELECT
         a.anime_id AS id,
+        a.title_kor_manual AS titleMan,
         a.title_kor AS titleKor,
         a.title_english AS titleEng,
         a.title_romaj AS titleRom,

--- a/src/main/resources/mapper/explore/UserSignUpAnimeQueryMapper.xml
+++ b/src/main/resources/mapper/explore/UserSignUpAnimeQueryMapper.xml
@@ -60,6 +60,7 @@
           resultType="com.anipick.backend.explore.dto.SignUpPopularAnimeAllTitleItemDto">
          SELECT a.popularity AS score,
                 a.anime_id AS animeId,
+                a.title_kor_manual AS titleMan,
                 a.title_kor AS titleKor,
                 a.title_english AS titleEng,
                 a.title_romaj AS titleRom,

--- a/src/main/resources/mapper/home/HomeQueryMapper.xml
+++ b/src/main/resources/mapper/home/HomeQueryMapper.xml
@@ -6,6 +6,7 @@
     <select id="selectHomeTrendingRanking" resultType="com.anipick.backend.home.dto.TrendingRankingFromQueryDto">
         SELECT
             a.anime_id AS animeId,
+            a.title_kor_manual AS titleMan,
             a.title_kor AS titleKor,
             a.title_english AS titleEng,
             a.title_romaj AS titleRom,
@@ -29,6 +30,7 @@
             r.review_id AS reviewId,
             u.user_id AS userId,
             r.anime_id AS animeId,
+            a.title_kor_manual AS titleMan,
             a.title_kor AS titleKor,
             a.title_english AS titleEng,
             a.title_romaj AS titleRom,
@@ -63,6 +65,7 @@
 
     <select id="selectHomeComingSoonAnimes" resultType="com.anipick.backend.anime.dto.ComingSoonItemAllTitleDto">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,

--- a/src/main/resources/mapper/mypage/MyPageQueryMapper.xml
+++ b/src/main/resources/mapper/mypage/MyPageQueryMapper.xml
@@ -15,6 +15,7 @@
         SELECT
             ual.anime_id AS animeId,
             ual.anime_like_id AS animeLikeId,
+            a.title_kor_manual AS titleMan,
             a.title_kor AS titleKor,
             a.title_english AS titleEng,
             a.title_romaj AS titleRom,
@@ -51,6 +52,7 @@
         SELECT
             a.anime_id AS animeId,
             uas.user_anime_status_id AS userAnimeStatusId,
+            a.title_kor_manual AS titleMan,
             a.title_kor AS titleKor,
             a.title_english AS titleEng,
             a.title_romaj AS titleRom,
@@ -73,6 +75,7 @@
         SELECT
             a.anime_id AS animeId,
             uas.user_anime_status_id AS userAnimeStatusId,
+            a.title_kor_manual AS titleMan,
             a.title_kor AS titleKor,
             a.title_english AS titleEng,
             a.title_romaj AS titleRom,
@@ -95,6 +98,7 @@
         SELECT
             a.anime_id AS animeId,
             uas.user_anime_status_id AS userAnimeStatusId,
+            a.title_kor_manual AS titleMan,
             a.title_kor AS titleKor,
             a.title_english AS titleEng,
             a.title_romaj AS titleRom,
@@ -124,6 +128,7 @@
     <select id="getMyAnimesReviewsAll" resultType="com.anipick.backend.mypage.dto.AnimesAllTitleReviewDto">
         SELECT
             a.anime_id AS animeId,
+            a.title_kor_manual AS titleMan,
             a.title_kor AS titleKor,
             a.title_english AS titleEng,
             a.title_romaj AS titleRom,
@@ -196,6 +201,7 @@
     <select id="getMyAnimesReviewsOnly" resultType="com.anipick.backend.mypage.dto.AnimesAllTitleReviewDto">
         SELECT
             a.anime_id AS animeId,
+            a.title_kor_manual AS titleMan,
             a.title_kor AS titleKor,
             a.title_english AS titleEng,
             a.title_romaj AS titleRom,

--- a/src/main/resources/mapper/person/PersonQueryMapper.xml
+++ b/src/main/resources/mapper/person/PersonQueryMapper.xml
@@ -29,6 +29,7 @@
     <select id="selectWorksByActor" resultType="com.anipick.backend.person.dto.PersonAnimeWorkAllTitleAndNameDto">
         SELECT a.anime_id AS animeId,
                a.popularity AS popularity,
+               a.title_kor_manual AS animeTitleMan,
                a.title_kor AS animeTitleKor,
                a.title_english AS animeTitleEng,
                a.title_romaj AS animeTitleRom,

--- a/src/main/resources/mapper/ranking/RankingQueryMapper.xml
+++ b/src/main/resources/mapper/ranking/RankingQueryMapper.xml
@@ -5,6 +5,7 @@
 <mapper namespace="com.anipick.backend.ranking.mapper.RankingMapper">
     <resultMap id="RankingResultMap" type="com.anipick.backend.ranking.dto.RankingAnimesFromQueryDto">
         <id property="animeId" column="animeId"/>
+        <result property="titleMan" column="titleMan"/>
         <result property="titleKor" column="titleKor"/>
         <result property="titleEng" column="titleEng"/>
         <result property="titleRom" column="titleRom"/>
@@ -32,6 +33,7 @@
     <select id="getYearSeasonRankingPaging" resultMap="RankingResultMap">
         SELECT
             DISTINCT(a.anime_id) AS animeId,
+            a.title_kor_manual AS titleMan,
             a.title_kor AS titleKor,
             a.title_english AS titleEng,
             a.title_romaj AS titleRom,
@@ -65,6 +67,7 @@
     <select id="getAllTimeRankingPaging" resultMap="RankingResultMap">
         SELECT
             DISTINCT(a.anime_id) AS animeId,
+            a.title_kor_manual AS titleMan,
             a.title_kor AS titleKor,
             a.title_english AS titleEng,
             a.title_romaj AS titleRom,

--- a/src/main/resources/mapper/ranking/RealTimeRankingQueryMapper.xml
+++ b/src/main/resources/mapper/ranking/RealTimeRankingQueryMapper.xml
@@ -5,6 +5,7 @@
 <mapper namespace="com.anipick.backend.ranking.mapper.RealTimeRankingMapper">
     <resultMap id="RankingResultMap" type="com.anipick.backend.ranking.dto.RealTimeRankingAnimesFromQueryDto">
         <id property="animeId" column="animeId"/>
+        <result property="titleMan" column="titleMan"/>
         <result property="titleKor" column="titleKor"/>
         <result property="titleEng" column="titleEng"/>
         <result property="titleRom" column="titleRom"/>
@@ -17,6 +18,7 @@
     <select id="getRealTimeRanking" resultMap="RankingResultMap">
         SELECT
             DISTINCT(a.anime_id) AS animeId,
+            a.title_kor_manual AS titleMan,
             a.title_kor AS titleKor,
             a.title_english AS titleEng,
             a.title_romaj AS titleRom,
@@ -44,6 +46,7 @@
     <select id="getRealTimeRankingPaging" resultMap="RankingResultMap">
         SELECT
             DISTINCT(a.anime_id) AS animeId,
+            a.title_kor_manual AS titleMan,
             a.title_kor AS titleKor,
             a.title_english AS titleEng,
             a.title_romaj AS titleRom,

--- a/src/main/resources/mapper/recommendation/RecommendMapper.xml
+++ b/src/main/resources/mapper/recommendation/RecommendMapper.xml
@@ -7,6 +7,7 @@
             parameterType="com.anipick.backend.recommendation.dto.RecentHighCountOnlyRequest"
             resultType="com.anipick.backend.recommendation.dto.AnimeAllTitleItemRecommendTagCountDto">
         SELECT a.anime_id AS animeId,
+               an.title_kor_manual AS titleMan,
                an.title_kor AS titleKor,
                an.title_english AS titleEng,
                an.title_romaj AS titleRom,
@@ -68,6 +69,7 @@
             parameterType="com.anipick.backend.recommendation.dto.TagBasedCountOnlyRequest"
             resultType="com.anipick.backend.recommendation.dto.AnimeAllTitleItemRecommendTagCountDto">
         SELECT a.anime_id AS animeId,
+               an.title_kor_manual AS titleMan,
                an.title_kor AS titleKor,
                an.title_english AS titleEng,
                an.title_romaj AS titleRom,

--- a/src/main/resources/mapper/review/RecentReviewQueryMapper.xml
+++ b/src/main/resources/mapper/review/RecentReviewQueryMapper.xml
@@ -25,6 +25,7 @@
             r.review_id AS reviewId,
             u.user_id AS userId,
             r.anime_id AS animeId,
+            a.title_kor_manual AS titleMan,
             a.title_kor AS titleKor,
             a.title_english AS titleEng,
             a.title_romaj AS titleRom,

--- a/src/main/resources/mapper/search/SearchQueryMapper.xml
+++ b/src/main/resources/mapper/search/SearchQueryMapper.xml
@@ -7,6 +7,7 @@
 
     <select id="selectSearchWeekBestAnimes" resultType="com.anipick.backend.anime.dto.AnimeAllTitleImgDto">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,
@@ -41,6 +42,7 @@
 
     <select id="selectSearchAnimes" parameterType="map" resultType="com.anipick.backend.anime.dto.AnimeAllTitleImgDto">
         SELECT a.anime_id AS animeId,
+               a.title_kor_manual AS titleMan,
                a.title_kor AS titleKor,
                a.title_english AS titleEng,
                a.title_romaj AS titleRom,


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->

- 어드민에서 애니 제목, 줄거리를 수정했으나 배치 서버로 인해 원복된 현상이 있었음.
- Anime 테이블에 어드민에서 수정한 값으로 저장하는 컬럼들을 새로 추가(`title_kor_manual`, `description_kor_manual`)
- 우선순위 : `수동 번역본 -> 번역 -> 영어 -> 로마자 -> 원어`


---

**work-details**

- 제목, 줄거리에 우선순위로 표시되는 서비스(+ dto), 쿼리에 위 컬럼들 추가
  - API 전부 로컬에서 확인하기 어렵기 때문에 해당 브랜치로 운영에 띄워보고, merge 해야합니다.ㅠㅠ

- 커밋 작업 순서
  - `LocalizationUtil` 클래스에 제목, 줄거리 추가
  - 사용되는 `~QueryMapper`를 도메인 별로 위 컬럼들 추가
  - 사용되는 `~Service`를 도메인 별로 위 컬럼들 추가

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test
