### PR TITLE
fix/JwtAuthFilter를 non-blocking으로 변경하여 공개 엔드포인트 인증 차단 해결

### DIFF
--- a/src/main/java/com/anipick/backend/common/auth/JwtAuthFilter.java
+++ b/src/main/java/com/anipick/backend/common/auth/JwtAuthFilter.java
@@ -1,17 +1,14 @@
 package com.anipick.backend.common.auth;
 
 import com.anipick.backend.common.auth.service.CustomUserDetailsService;
-import com.anipick.backend.common.dto.ApiResponse;
-import com.anipick.backend.common.exception.ErrorCode;
 import com.anipick.backend.user.domain.UserDefaults;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.*;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -38,38 +35,25 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String accessToken = jwtTokenProvider.resolveAccessToken(request);
 
         try {
-            if(accessToken != null) {
-                jwtTokenProvider.validateToken(accessToken); //토큰 유효성 검사
+            if (accessToken != null) {
+                jwtTokenProvider.validateToken(accessToken); // 토큰 유효성 검사
 
                 String checkLogout = redisTemplate.opsForValue().get(UserDefaults.DEFAULT_LOGOUT_LIST_FORMAT_KEY + accessToken);
-                if(checkLogout != null) {
-                    response.setStatus(HttpStatus.UNAUTHORIZED.value());
-                    response.setContentType("application/json;charset=UTF-8");
-
-                    ApiResponse<Object> apiResponse = ApiResponse.error(ErrorCode.REQUESTED_TOKEN_INVALID);
-                    ObjectMapper mapper = new ObjectMapper();
-                    String json = mapper.writeValueAsString(apiResponse);
-                    response.getWriter().write(json);
-                    
-                    return;
+                if (checkLogout == null) {
+                    String emailFromToken = jwtTokenProvider.getEmailFromToken(accessToken);
+                    UserDetails userDetails = userDetailsService.loadUserByUsername(emailFromToken);
+                    Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
-                
-                String emailFromToken = jwtTokenProvider.getEmailFromToken(accessToken);
-                UserDetails userDetails = userDetailsService.loadUserByUsername(emailFromToken);
-                Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                // 로그아웃(블랙리스트)된 토큰이면 인증을 세팅하지 않는다 → 보호 엔드포인트는 EntryPoint가 401 처리
             }
-
-            filterChain.doFilter(request, response);
         } catch (Exception e) {
-            log.error(e.getMessage());
-            response.setStatus(HttpStatus.UNAUTHORIZED.value());
-            response.setContentType("application/json;charset=UTF-8");
-
-            ApiResponse<Object> apiResponse = ApiResponse.error(ErrorCode.REQUESTED_TOKEN_INVALID);
-            ObjectMapper mapper = new ObjectMapper();
-            String json = mapper.writeValueAsString(apiResponse);
-            response.getWriter().write(json);
+            // 만료·무효·orphan 토큰: 인증만 생략하고 요청은 계속 진행한다.
+            // 공개 엔드포인트(login/oauth 등)는 그대로 통과, 보호 엔드포인트는 Spring Security가 401 처리한다.
+            log.debug("JWT 인증 스킵: {}", e.getMessage());
+            SecurityContextHolder.clearContext();
         }
+
+        filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/anipick/backend/common/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/anipick/backend/common/auth/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package com.anipick.backend.common.auth;
+
+import com.anipick.backend.common.dto.ApiResponse;
+import com.anipick.backend.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 보호 엔드포인트에 인증 없이(또는 무효 토큰으로) 접근했을 때의 401 응답을 담당한다.
+ * JwtAuthFilter가 non-blocking으로 동작하므로, 토큰 오류 시 실제 401 처리는 이곳에서 이뤄진다.
+ */
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<Object> apiResponse = ApiResponse.error(ErrorCode.REQUESTED_TOKEN_INVALID);
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+}

--- a/src/main/java/com/anipick/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/anipick/backend/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.anipick.backend.common.config;
 
 import com.anipick.backend.common.auth.JwtAuthFilter;
+import com.anipick.backend.common.auth.JwtAuthenticationEntryPoint;
 import com.anipick.backend.common.auth.JwtTokenProvider;
 import com.anipick.backend.common.auth.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class SecurityConfig {
     private final CustomUserDetailsService userDetailsService;
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate<String, String> redisTemplate;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
@@ -37,7 +39,9 @@ public class SecurityConfig {
                                                 /**
                                                  * API
                                                  */
-                                                "/api/users/**",
+                                                "/api/users/login",
+                                                "/api/users/signup",
+                                                "/api/users/logout",
                                                 "/api/auth/**",
                                                 "/api/oauth/**",
                                                 "/api/animes/meta-data-group",
@@ -73,6 +77,10 @@ public class SecurityConfig {
                 .sessionManagement(
                         session ->
                                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .exceptionHandling(
+                        exception ->
+                                exception.authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 )
                 .addFilterBefore(new JwtAuthFilter(userDetailsService, jwtTokenProvider, redisTemplate), UsernamePasswordAuthenticationFilter.class)
                 .build();


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->
- JwtAuthFilter는 OncePerRequestFilter라 permitAll 여부와 무관하게 모든 요청에서 실행됨.
- Authorization 헤더에 토큰이 있으면 검증 후 만료/무효 시 401을 던지고 요청을 중단 → oauth/login 같은 공개(로그인) 엔드포인트조차 컨트롤러 도달 전에 막힘.
- 앱이 공용 인터셉터로 모든 요청에 access token을 붙이는 구조라, 만료·orphan 토큰을 든 사용자는 복구 경로(oauth/refresh)마저 막혀 잠금 루프에 빠짐. (prod 로그의 "토큰 만료"/"가입된 계정 없음" 폭증 원인)

---

**work-details**
- JwtAuthFilter를 non-blocking으로 변경
  - 토큰이 만료/무효/orphan이면 401을 던지지 않고 인증만 생략한 채 요청을 계속 진행.
  - 유효한 토큰일 때만 SecurityContext에 인증 세팅.
  - 정상 인증 실패 로그 레벨을 error → debug로 하향.
- JwtAuthenticationEntryPoint 추가
  - 보호 엔드포인트의 401 응답을 기존과 동일한 ApiResponse.error(REQUESTED_TOKEN_INVALID) JSON 형식으로 반환 → 앱 응답 계약 유지.
- SecurityConfig 정리
  - permitAll의 /api/users/** 를 /login, /signup, /logout 으로 축소.
  - 인증이 필요한 /api/users/{animeId}/status 엔드포인트를 authenticated로 이동(잘못된 토큰 시 500 NPE → 정상 401).
  - exceptionHandling에 JwtAuthenticationEntryPoint 연결.
 
 효과
- 공개 엔드포인트(oauth/login/signup)는 헤더에 만료·orphan 토큰이 있어도 통과 → 로그인 정상화.
- 보호 엔드포인트는 유효 토큰이면 기존과 동일, 무효 토큰이면 동일한 401 JSON 반환.
- 앱 수정 없이 백엔드만으로 로그인 잠김 및 에러 로그 폭증 해소.
**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test