### PR TITLE
fix/회원가입 평가 완료 시 추천 상태 중복 삽입 예외 수정

### DIFF
--- a/src/main/java/com/anipick/backend/review/service/ReviewService.java
+++ b/src/main/java/com/anipick/backend/review/service/ReviewService.java
@@ -7,6 +7,8 @@ import com.anipick.backend.common.exception.CustomException;
 import com.anipick.backend.common.exception.ErrorCode;
 import com.anipick.backend.image.domain.ImageDefaults;
 import com.anipick.backend.like.mapper.LikeMapper;
+import com.anipick.backend.recommendation.domain.UserRecommendMode;
+import com.anipick.backend.recommendation.domain.UserRecommendState;
 import com.anipick.backend.recommendation.mapper.UserRecommendStateMapper;
 import com.anipick.backend.review.domain.Review;
 import com.anipick.backend.review.dto.*;
@@ -164,7 +166,12 @@ public class ReviewService {
                 .toList();
         animeMapper.updateReviewAverageScoresByAnimeIds(animeIds);
 
-        userRecommendStateMapper.insertTagBasedState(userId);
+        UserRecommendState recommendState = userRecommendStateMapper.findByUserId(userId);
+        if (recommendState == null) {
+            userRecommendStateMapper.insertTagBasedState(userId);
+        } else {
+            userRecommendStateMapper.updateMode(userId, UserRecommendMode.TAG_BASED, null);
+        }
 
         userMapper.updateReviewCompletedYn(userId);
     }


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->
- 홈/추천/개별평가 등 다른 경로에서 Userrecommendationstate 행이 먼저
생성된 경우, createAndUpdateSignupReview의 insertTagBasedState가 무조건
INSERT를 시도해 DuplicateKeyException이 발생

---

**work-details**
 트랜잭션 롤백으로 updateReviewCompletedYn이 실행되지 못해
  review_completed_yn이 false로 남고, 재로그인 시 회원가입 애니 평가
  화면이 다시 노출되는 문제가 발생
- 나머지 세 호출부와 동일하게 findByUserId 조회 후 행이 없으면 insert,
  있으면 updateMode(TAG_BASED)로 갱신하도록 멱등하게 수정

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->

### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [ ] API Test
