### PR TITLE
feat/커뮤니티 - 애니 시리즈 게시판

### DIFF
--- a/src/main/java/com/anipick/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/anipick/backend/common/exception/ErrorCode.java
@@ -78,7 +78,18 @@ public enum ErrorCode {
 	 * Image
 	 */
 	INVAILD_IMAGE_EXTENSION(901, "유효한 이미지 확장자가 아님", null),
-	IMAGE_DATA_NOT_FOUND(902, "이미지 데이터 찾을 수 없음", null);
+	IMAGE_DATA_NOT_FOUND(902, "이미지 데이터 찾을 수 없음", null),
+	IMAGE_SIZE_EXCEEDED(903, "이미지 용량 초과", "이미지 용량은 10MB 이하만 업로드할 수 있습니다."),
+	/**
+	 * Community
+	 */
+	ANIME_NOT_FOUND(1001, "애니 찾을 수 없음", null),
+	SERIES_NOT_FOUND(1002, "시리즈 찾을 수 없음", null),
+	COMMUNITY_POST_NOT_FOUND(1003, "게시글 찾을 수 없음", null),
+	COMMUNITY_POST_NOT_OWNER(1004, "본인이 작성한 게시글이 아님", null),
+	COMMUNITY_POST_TITLE_LENGTH_INVALID(1005, "게시글 제목 길이 오류", "제목은 1~50자로 입력해 주세요."),
+	COMMUNITY_POST_CONTENT_LENGTH_INVALID(1006, "게시글 내용 길이 오류", "내용은 1~1000자로 입력해 주세요."),
+	COMMUNITY_POST_IMAGE_COUNT_EXCEEDED(1007, "첨부 이미지 개수 초과", "이미지는 최대 5장까지 첨부할 수 있습니다.");
 
 	private final int code;
 	private final String errorReason;

--- a/src/main/java/com/anipick/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/anipick/backend/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.anipick.backend.common.exception;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import com.anipick.backend.common.dto.ApiResponse;
 
@@ -25,6 +26,13 @@ public class GlobalExceptionHandler {
 	public ApiResponse<?> handleBadRequest(HttpMessageNotReadableException ex) {
 		log.error("log info {} : ", ex.getMessage());
 		return ApiResponse.error(ErrorCode.BAD_REQUEST);
+	}
+
+	// 파일 업로드 용량 초과 (spring.servlet.multipart.max-file-size)
+	@ExceptionHandler(MaxUploadSizeExceededException.class)
+	public ApiResponse<?> handleMaxUploadSize(MaxUploadSizeExceededException ex) {
+		log.error("log info {} : ", ex.getMessage());
+		return ApiResponse.error(ErrorCode.IMAGE_SIZE_EXCEEDED);
 	}
 
 	// 그 외 모든 예외 (서버 오류)

--- a/src/main/java/com/anipick/backend/community/controller/CommunityBoardController.java
+++ b/src/main/java/com/anipick/backend/community/controller/CommunityBoardController.java
@@ -1,0 +1,40 @@
+package com.anipick.backend.community.controller;
+
+import com.anipick.backend.common.auth.dto.CustomUserDetails;
+import com.anipick.backend.common.dto.ApiResponse;
+import com.anipick.backend.community.dto.BoardByAnimeResultDto;
+import com.anipick.backend.community.dto.PostListPageDto;
+import com.anipick.backend.community.service.CommunityBoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/community/boards")
+@RequiredArgsConstructor
+public class CommunityBoardController {
+
+    private final CommunityBoardService communityBoardService;
+
+    @GetMapping("/by-anime/{animeId}")
+    public ApiResponse<BoardByAnimeResultDto> getBoardByAnime(
+            @PathVariable(name = "animeId") Long animeId
+    ) {
+        BoardByAnimeResultDto result = communityBoardService.getBoardByAnime(animeId);
+        return ApiResponse.success(result);
+    }
+
+    @GetMapping("/{seriesId}/posts")
+    public ApiResponse<PostListPageDto> getPosts(
+            @PathVariable(name = "seriesId") Long seriesId,
+            @RequestParam(value = "sort", defaultValue = "latest") String sort,
+            @RequestParam(value = "lastValue", required = false) String lastValue,
+            @RequestParam(value = "lastId", required = false) Long lastId,
+            @RequestParam(value = "size", defaultValue = "20") int size,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Long userId = user.getUserId();
+        PostListPageDto result = communityBoardService.getPosts(seriesId, sort, lastValue, lastId, size, userId);
+        return ApiResponse.success(result);
+    }
+}

--- a/src/main/java/com/anipick/backend/community/controller/CommunityPostController.java
+++ b/src/main/java/com/anipick/backend/community/controller/CommunityPostController.java
@@ -1,0 +1,81 @@
+package com.anipick.backend.community.controller;
+
+import com.anipick.backend.common.auth.dto.CustomUserDetails;
+import com.anipick.backend.common.dto.ApiResponse;
+import com.anipick.backend.community.dto.PostCreateRequest;
+import com.anipick.backend.community.dto.PostCreateResultDto;
+import com.anipick.backend.community.dto.PostDetailDto;
+import com.anipick.backend.community.dto.PostUpdateRequest;
+import com.anipick.backend.community.service.CommunityPostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/community/posts")
+@RequiredArgsConstructor
+public class CommunityPostController {
+
+    private final CommunityPostService communityPostService;
+
+    @PostMapping
+    public ApiResponse<PostCreateResultDto> createPost(
+            @RequestBody PostCreateRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Long userId = user.getUserId();
+        PostCreateResultDto result = communityPostService.createPost(request, userId);
+        return ApiResponse.success(result);
+    }
+
+    @GetMapping("/{postId}")
+    public ApiResponse<PostDetailDto> getPostDetail(
+            @PathVariable(name = "postId") Long postId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Long userId = user.getUserId();
+        PostDetailDto result = communityPostService.getPostDetail(postId, userId);
+        return ApiResponse.success(result);
+    }
+
+    @PatchMapping("/{postId}")
+    public ApiResponse<Void> updatePost(
+            @PathVariable(name = "postId") Long postId,
+            @RequestBody PostUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Long userId = user.getUserId();
+        communityPostService.updatePost(postId, request, userId);
+        return ApiResponse.success();
+    }
+
+    @DeleteMapping("/{postId}")
+    public ApiResponse<Void> deletePost(
+            @PathVariable(name = "postId") Long postId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Long userId = user.getUserId();
+        communityPostService.deletePost(postId, userId);
+        return ApiResponse.success();
+    }
+
+    @PostMapping("/{postId}/like")
+    public ApiResponse<Void> likePost(
+            @PathVariable(name = "postId") Long postId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Long userId = user.getUserId();
+        communityPostService.likePost(userId, postId);
+        return ApiResponse.success();
+    }
+
+    @DeleteMapping("/{postId}/like")
+    public ApiResponse<Void> unlikePost(
+            @PathVariable(name = "postId") Long postId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Long userId = user.getUserId();
+        communityPostService.unlikePost(userId, postId);
+        return ApiResponse.success();
+    }
+}

--- a/src/main/java/com/anipick/backend/community/domain/CommunityPost.java
+++ b/src/main/java/com/anipick/backend/community/domain/CommunityPost.java
@@ -1,0 +1,28 @@
+package com.anipick.backend.community.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommunityPost {
+    private Long postId;
+    private Long seriesId;
+    private Long userId;
+    private String title;
+    private String content;
+    private Boolean isSpoiler;
+    private Long viewCount;
+    private Long likeCount;
+    private Long commentCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/anipick/backend/community/domain/CommunityPostSort.java
+++ b/src/main/java/com/anipick/backend/community/domain/CommunityPostSort.java
@@ -1,0 +1,55 @@
+package com.anipick.backend.community.domain;
+
+import com.anipick.backend.common.exception.CustomException;
+import com.anipick.backend.common.exception.ErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 게시글 목록 정렬 옵션.
+ * - latest: 최신순 (post_id DESC)
+ * - popularDaily/Weekly/Monthly: 해당 기간 내 증가한 좋아요 수 기준 인기순
+ *   (community_post_like.created_at 이 기간 시작 이후인 것만 카운트)
+ */
+@Getter
+@AllArgsConstructor
+public enum CommunityPostSort {
+    LATEST("latest"),
+    POPULAR_DAILY("popularDaily"),
+    POPULAR_WEEKLY("popularWeekly"),
+    POPULAR_MONTHLY("popularMonthly");
+
+    private final String code;
+
+    public static CommunityPostSort of(String code) {
+        if (code == null) {
+            return LATEST;
+        }
+        return switch (code) {
+            case "latest" -> LATEST;
+            case "popularDaily" -> POPULAR_DAILY;
+            case "popularWeekly" -> POPULAR_WEEKLY;
+            case "popularMonthly" -> POPULAR_MONTHLY;
+            default -> throw new CustomException(ErrorCode.BAD_REQUEST);
+        };
+    }
+
+    public boolean isPopular() {
+        return this != LATEST;
+    }
+
+    /**
+     * 인기순 집계 시작 시각. 최신순이면 null.
+     */
+    public LocalDateTime periodStart(LocalDateTime now) {
+        return switch (this) {
+            case POPULAR_DAILY -> now.minusDays(1);
+            case POPULAR_WEEKLY -> now.minusWeeks(1);
+            case POPULAR_MONTHLY -> now.minusMonths(1);
+            case LATEST -> null;
+        };
+    }
+}

--- a/src/main/java/com/anipick/backend/community/dto/BoardByAnimeResultDto.java
+++ b/src/main/java/com/anipick/backend/community/dto/BoardByAnimeResultDto.java
@@ -1,0 +1,28 @@
+package com.anipick.backend.community.dto;
+
+import com.anipick.backend.anime.dto.GenreDto;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * GET /api/community/boards/by-anime/{animeId} 응답.
+ * hasBoard=false(게시판 없음)면 postCount 는 응답에서 제외된다(null → NON_NULL).
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class BoardByAnimeResultDto {
+    private Boolean hasBoard;
+    private Long seriesId;
+    private String title;
+    private String coverImageUrl;
+    private List<GenreDto> genres;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Long postCount;
+}

--- a/src/main/java/com/anipick/backend/community/dto/BoardInfoRawDto.java
+++ b/src/main/java/com/anipick/backend/community/dto/BoardInfoRawDto.java
@@ -1,0 +1,27 @@
+package com.anipick.backend.community.dto;
+
+import lombok.Getter;
+
+/**
+ * anime LEFT JOIN series_anime LEFT JOIN series 조회 원본.
+ * seriesId 가 null 이면 게시판(시리즈 매핑) 없음 → 애니 자체 값(anime*)으로 fallback.
+ * 제목은 LocalizationUtil 로 서비스에서 픽.
+ */
+@Getter
+public class BoardInfoRawDto {
+    // 게시판(시리즈) 존재 시 사용
+    private Long seriesId;
+    private String titleKor;
+    private String titleEng;
+    private String titleRom;
+    private String titleNat;
+    private String coverImageUrl;
+
+    // 게시판 없을 때 팝업용 fallback (애니 자체 정보)
+    private String animeTitleMan;
+    private String animeTitleKor;
+    private String animeTitleEng;
+    private String animeTitleRom;
+    private String animeTitleNat;
+    private String animeCoverImageUrl;
+}

--- a/src/main/java/com/anipick/backend/community/dto/PostCreateRequest.java
+++ b/src/main/java/com/anipick/backend/community/dto/PostCreateRequest.java
@@ -1,0 +1,40 @@
+package com.anipick.backend.community.dto;
+
+import com.anipick.backend.common.exception.CustomException;
+import com.anipick.backend.common.exception.ErrorCode;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * POST /api/community/posts 요청.
+ */
+@Getter
+public class PostCreateRequest {
+    private Long seriesId;
+    private String title;
+    private String content;
+    private Boolean isSpoiler;
+    private List<Long> imageIds;
+
+    private static final int TITLE_MAX = 50;
+    private static final int CONTENT_MAX = 1000;
+    private static final int IMAGE_MAX = 5;
+
+    public void validate() {
+        if (title == null || title.isBlank() || title.length() > TITLE_MAX) {
+            throw new CustomException(ErrorCode.COMMUNITY_POST_TITLE_LENGTH_INVALID);
+        }
+        if (content == null || content.isBlank() || content.length() > CONTENT_MAX) {
+            throw new CustomException(ErrorCode.COMMUNITY_POST_CONTENT_LENGTH_INVALID);
+        }
+        if (imageIds != null && imageIds.size() > IMAGE_MAX) {
+            throw new CustomException(ErrorCode.COMMUNITY_POST_IMAGE_COUNT_EXCEEDED);
+        }
+    }
+
+    public boolean getSpoilerOrDefault() {
+        return isSpoiler != null && isSpoiler;
+    }
+}

--- a/src/main/java/com/anipick/backend/community/dto/PostCreateResultDto.java
+++ b/src/main/java/com/anipick/backend/community/dto/PostCreateResultDto.java
@@ -1,0 +1,17 @@
+package com.anipick.backend.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * POST /api/community/posts 응답.
+ */
+@Getter
+@AllArgsConstructor
+public class PostCreateResultDto {
+    private Long postId;
+
+    public static PostCreateResultDto from(Long postId) {
+        return new PostCreateResultDto(postId);
+    }
+}

--- a/src/main/java/com/anipick/backend/community/dto/PostDetailDto.java
+++ b/src/main/java/com/anipick/backend/community/dto/PostDetailDto.java
@@ -1,0 +1,36 @@
+package com.anipick.backend.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+
+import java.util.List;
+
+/**
+ * GET /api/community/posts/{postId} 응답.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostDetailDto {
+    private Long postId;
+    private Long seriesId;
+    private String seriesTitle;
+    private Long userId;
+    private String nickname;
+    private Long profileImageId;
+    private String title;
+    private String content;
+    private Boolean isSpoiler;
+    private List<Long> imageIds;
+    private Long viewCount;
+    private Long likeCount;
+    private Long commentCount;
+    private Boolean isLiked;
+    private Boolean isMine;
+    private Boolean isAuthorBlocked;
+    private String createdAt;
+}

--- a/src/main/java/com/anipick/backend/community/dto/PostDetailRawDto.java
+++ b/src/main/java/com/anipick/backend/community/dto/PostDetailRawDto.java
@@ -1,0 +1,28 @@
+package com.anipick.backend.community.dto;
+
+import lombok.Getter;
+
+/**
+ * 게시글 상세 조회 원본(이미지 목록 제외). 날짜 포맷/플래그는 서비스에서 가공.
+ */
+@Getter
+public class PostDetailRawDto {
+    private Long postId;
+    private Long seriesId;
+    private String seriesTitleKor;
+    private String seriesTitleEng;
+    private String seriesTitleRom;
+    private String seriesTitleNat;
+    private Long userId;
+    private String nickname;
+    private Long profileImageId;
+    private String title;
+    private String content;
+    private Boolean isSpoiler;
+    private Long viewCount;
+    private Long likeCount;
+    private Long commentCount;
+    private Boolean isLiked;
+    private Boolean isAuthorBlocked;
+    private String createdAt;
+}

--- a/src/main/java/com/anipick/backend/community/dto/PostListItemDto.java
+++ b/src/main/java/com/anipick/backend/community/dto/PostListItemDto.java
@@ -1,0 +1,38 @@
+package com.anipick.backend.community.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+
+/**
+ * 게시글 목록 아이템.
+ * 프로필/썸네일 이미지는 imageId 만 내려주고 실제 조회는 /api/image/{imageId} 사용.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostListItemDto {
+    private Long postId;
+    private Long userId;
+    private String nickname;
+    private Long profileImageId;
+    private String title;
+    private String content;
+    private Long thumbnailImageId;
+    private Boolean isSpoiler;
+    private Long viewCount;
+    private Long likeCount;
+    private Long commentCount;
+    private String createdAt;
+
+    /**
+     * 인기순 정렬 시 커서(lastValue)로 쓰는 기간 내 좋아요 수. 응답 JSON 에는 노출하지 않음.
+     */
+    @JsonIgnore
+    private Long periodLikeCount;
+}

--- a/src/main/java/com/anipick/backend/community/dto/PostListPageDto.java
+++ b/src/main/java/com/anipick/backend/community/dto/PostListPageDto.java
@@ -1,0 +1,24 @@
+package com.anipick.backend.community.dto;
+
+import com.anipick.backend.common.dto.CursorDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+
+import java.util.List;
+
+/**
+ * GET /api/community/boards/{seriesId}/posts 응답.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostListPageDto {
+    private Long count;
+    private CursorDto cursor;
+    private List<PostListItemDto> posts;
+}

--- a/src/main/java/com/anipick/backend/community/dto/PostUpdateRequest.java
+++ b/src/main/java/com/anipick/backend/community/dto/PostUpdateRequest.java
@@ -1,0 +1,39 @@
+package com.anipick.backend.community.dto;
+
+import com.anipick.backend.common.exception.CustomException;
+import com.anipick.backend.common.exception.ErrorCode;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * PATCH /api/community/posts/{postId} 요청.
+ */
+@Getter
+public class PostUpdateRequest {
+    private String title;
+    private String content;
+    private Boolean isSpoiler;
+    private List<Long> imageIds;
+
+    private static final int TITLE_MAX = 50;
+    private static final int CONTENT_MAX = 1000;
+    private static final int IMAGE_MAX = 5;
+
+    public void validate() {
+        if (title == null || title.isBlank() || title.length() > TITLE_MAX) {
+            throw new CustomException(ErrorCode.COMMUNITY_POST_TITLE_LENGTH_INVALID);
+        }
+        if (content == null || content.isBlank() || content.length() > CONTENT_MAX) {
+            throw new CustomException(ErrorCode.COMMUNITY_POST_CONTENT_LENGTH_INVALID);
+        }
+        if (imageIds != null && imageIds.size() > IMAGE_MAX) {
+            throw new CustomException(ErrorCode.COMMUNITY_POST_IMAGE_COUNT_EXCEEDED);
+        }
+    }
+
+    public boolean getSpoilerOrDefault() {
+        return isSpoiler != null && isSpoiler;
+    }
+}

--- a/src/main/java/com/anipick/backend/community/mapper/CommunityBoardMapper.java
+++ b/src/main/java/com/anipick/backend/community/mapper/CommunityBoardMapper.java
@@ -1,0 +1,34 @@
+package com.anipick.backend.community.mapper;
+
+import com.anipick.backend.anime.dto.GenreDto;
+import com.anipick.backend.community.dto.BoardInfoRawDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface CommunityBoardMapper {
+
+    /**
+     * 애니 ID 로 매핑된 시리즈(게시판) 조회. 매핑이 없으면 null.
+     */
+    BoardInfoRawDto selectBoardByAnimeId(@Param("animeId") Long animeId);
+
+    /**
+     * 시리즈 대표작(sort_order 최소) 애니의 장르 목록.
+     */
+    List<GenreDto> selectRepresentativeGenresBySeriesId(@Param("seriesId") Long seriesId);
+
+    /**
+     * 게시판(시리즈)이 없을 때 팝업용으로 쓰는 애니 자체 장르 목록.
+     */
+    List<GenreDto> selectGenresByAnimeId(@Param("animeId") Long animeId);
+
+    /**
+     * 게시판의 활성 게시글 수(soft delete 제외).
+     */
+    Long countPostsBySeriesId(@Param("seriesId") Long seriesId);
+
+    boolean existsSeries(@Param("seriesId") Long seriesId);
+}

--- a/src/main/java/com/anipick/backend/community/mapper/CommunityPostLikeMapper.java
+++ b/src/main/java/com/anipick/backend/community/mapper/CommunityPostLikeMapper.java
@@ -1,0 +1,23 @@
+package com.anipick.backend.community.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface CommunityPostLikeMapper {
+
+    Boolean selectUserLikePost(
+            @Param("userId") Long userId,
+            @Param("postId") Long postId
+    );
+
+    void insertLikePost(
+            @Param("userId") Long userId,
+            @Param("postId") Long postId
+    );
+
+    void deleteLikePost(
+            @Param("userId") Long userId,
+            @Param("postId") Long postId
+    );
+}

--- a/src/main/java/com/anipick/backend/community/mapper/CommunityPostMapper.java
+++ b/src/main/java/com/anipick/backend/community/mapper/CommunityPostMapper.java
@@ -1,0 +1,87 @@
+package com.anipick.backend.community.mapper;
+
+import com.anipick.backend.community.domain.CommunityPost;
+import com.anipick.backend.community.dto.PostCreateRequest;
+import com.anipick.backend.community.dto.PostDetailRawDto;
+import com.anipick.backend.community.dto.PostListItemDto;
+import com.anipick.backend.community.dto.PostUpdateRequest;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Mapper
+public interface CommunityPostMapper {
+
+    /**
+     * 게시판 전체 게시글 수(차단 유저 글 제외, soft delete 제외).
+     */
+    Long countBoardPosts(
+            @Param("seriesId") Long seriesId,
+            @Param("userId") Long userId
+    );
+
+    /**
+     * 최신순 목록 (post_id DESC 커서).
+     */
+    List<PostListItemDto> selectLatestPosts(
+            @Param("seriesId") Long seriesId,
+            @Param("userId") Long userId,
+            @Param("lastId") Long lastId,
+            @Param("size") int size
+    );
+
+    /**
+     * 인기순 목록 (기간 내 좋아요 수 DESC, post_id DESC 커서).
+     */
+    List<PostListItemDto> selectPopularPosts(
+            @Param("seriesId") Long seriesId,
+            @Param("userId") Long userId,
+            @Param("periodStart") LocalDateTime periodStart,
+            @Param("lastValue") Long lastValue,
+            @Param("lastId") Long lastId,
+            @Param("size") int size
+    );
+
+    /**
+     * 게시글 상세(이미지 목록 제외). 삭제된 글은 조회되지 않음.
+     */
+    PostDetailRawDto selectPostDetail(
+            @Param("postId") Long postId,
+            @Param("userId") Long userId
+    );
+
+    List<Long> selectPostImageIds(@Param("postId") Long postId);
+
+    /**
+     * 소유자/존재 확인용. 삭제 여부와 관계없이 조회(삭제 글도 NOT_FOUND 처리 위해 서비스에서 판단).
+     */
+    CommunityPost selectPostForCheck(@Param("postId") Long postId);
+
+    void insertPost(CommunityPost post);
+
+    void insertPostImages(
+            @Param("postId") Long postId,
+            @Param("imageIds") List<Long> imageIds
+    );
+
+    void deletePostImages(@Param("postId") Long postId);
+
+    void updatePost(
+            @Param("postId") Long postId,
+            @Param("userId") Long userId,
+            @Param("request") PostUpdateRequest request
+    );
+
+    void softDeletePost(
+            @Param("postId") Long postId,
+            @Param("userId") Long userId
+    );
+
+    void increaseViewCount(@Param("postId") Long postId);
+
+    void increaseLikeCount(@Param("postId") Long postId);
+
+    void decreaseLikeCount(@Param("postId") Long postId);
+}

--- a/src/main/java/com/anipick/backend/community/service/CommunityBoardService.java
+++ b/src/main/java/com/anipick/backend/community/service/CommunityBoardService.java
@@ -1,0 +1,157 @@
+package com.anipick.backend.community.service;
+
+import com.anipick.backend.anime.dto.GenreDto;
+import com.anipick.backend.common.dto.CursorDto;
+import com.anipick.backend.common.exception.CustomException;
+import com.anipick.backend.common.exception.ErrorCode;
+import com.anipick.backend.common.util.LocalizationUtil;
+import com.anipick.backend.community.domain.CommunityPostSort;
+import com.anipick.backend.community.dto.BoardByAnimeResultDto;
+import com.anipick.backend.community.dto.BoardInfoRawDto;
+import com.anipick.backend.community.dto.PostListItemDto;
+import com.anipick.backend.community.dto.PostListPageDto;
+import com.anipick.backend.community.mapper.CommunityBoardMapper;
+import com.anipick.backend.community.mapper.CommunityPostMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommunityBoardService {
+
+    private final CommunityBoardMapper communityBoardMapper;
+    private final CommunityPostMapper communityPostMapper;
+
+    private static final DateTimeFormatter PARSER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy. MM. dd");
+
+    @Transactional(readOnly = true)
+    public BoardByAnimeResultDto getBoardByAnime(Long animeId) {
+        BoardInfoRawDto raw = communityBoardMapper.selectBoardByAnimeId(animeId);
+        if (raw == null) {
+            // 애니 자체가 존재하지 않음
+            throw new CustomException(ErrorCode.ANIME_NOT_FOUND);
+        }
+
+        // 시리즈 매핑이 없으면 게시판 없음 → 프론트 팝업용. 애니 자체 정보로 fallback.
+        if (raw.getSeriesId() == null) {
+            String animeTitle = LocalizationUtil.pickTitle(
+                    raw.getAnimeTitleMan(), raw.getAnimeTitleKor(), raw.getAnimeTitleEng(),
+                    raw.getAnimeTitleRom(), raw.getAnimeTitleNat());
+            List<GenreDto> genres = communityBoardMapper.selectGenresByAnimeId(animeId);
+
+            // postCount 는 세팅하지 않아 null → 응답에서 제외(@JsonInclude NON_NULL)
+            return BoardByAnimeResultDto.builder()
+                    .hasBoard(false)
+                    .seriesId(null)
+                    .title(animeTitle)
+                    .coverImageUrl(raw.getAnimeCoverImageUrl())
+                    .genres(genres)
+                    .build();
+        }
+
+        String title = LocalizationUtil.pickTitle(
+                null, raw.getTitleKor(), raw.getTitleEng(), raw.getTitleRom(), raw.getTitleNat());
+        List<GenreDto> genres = communityBoardMapper.selectRepresentativeGenresBySeriesId(raw.getSeriesId());
+        Long postCount = communityBoardMapper.countPostsBySeriesId(raw.getSeriesId());
+
+        return BoardByAnimeResultDto.builder()
+                .hasBoard(true)
+                .seriesId(raw.getSeriesId())
+                .title(title)
+                .coverImageUrl(raw.getCoverImageUrl())
+                .genres(genres)
+                .postCount(postCount)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public PostListPageDto getPosts(Long seriesId, String sortCode, String lastValue, Long lastId, int size, Long userId) {
+        if (!communityBoardMapper.existsSeries(seriesId)) {
+            throw new CustomException(ErrorCode.SERIES_NOT_FOUND);
+        }
+
+        CommunityPostSort sort = CommunityPostSort.of(sortCode);
+        Long total = communityPostMapper.countBoardPosts(seriesId, userId);
+
+        List<PostListItemDto> rawItems;
+        if (sort.isPopular()) {
+            LocalDateTime periodStart = sort.periodStart(LocalDateTime.now());
+            Long lastValueLong = parsePopularCursorValue(lastValue, lastId);
+            rawItems = communityPostMapper.selectPopularPosts(seriesId, userId, periodStart, lastValueLong, lastId, size);
+        } else {
+            rawItems = communityPostMapper.selectLatestPosts(seriesId, userId, lastId, size);
+        }
+
+        List<PostListItemDto> items = rawItems.stream()
+                .map(this::formatCreatedAt)
+                .toList();
+
+        CursorDto cursor = buildCursor(sort, rawItems);
+
+        return PostListPageDto.builder()
+                .count(total)
+                .cursor(cursor)
+                .posts(items)
+                .build();
+    }
+
+    /**
+     * 인기순 커서(lastValue = 기간 내 좋아요 수, lastId = post_id) 파싱.
+     * 둘은 항상 쌍으로 와야 한다. 한쪽만 오면 쿼리의 커서 조건이 통째로 무시되어
+     * 같은 페이지가 계속 반환되므로(무한 스크롤 루프) 요청 단계에서 막는다.
+     */
+    private Long parsePopularCursorValue(String lastValue, Long lastId) {
+        boolean hasLastValue = lastValue != null && !lastValue.isBlank();
+
+        // 첫 페이지
+        if (!hasLastValue && lastId == null) {
+            return null;
+        }
+        if (!hasLastValue || lastId == null) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+
+        try {
+            return Long.parseLong(lastValue.trim());
+        } catch (NumberFormatException e) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+    }
+
+    private CursorDto buildCursor(CommunityPostSort sort, List<PostListItemDto> rawItems) {
+        if (rawItems.isEmpty()) {
+            return sort.isPopular()
+                    ? CursorDto.of(sort.getCode(), null, null)
+                    : CursorDto.of(null);
+        }
+        PostListItemDto last = rawItems.get(rawItems.size() - 1);
+        if (sort.isPopular()) {
+            return CursorDto.of(sort.getCode(), last.getPostId(), String.valueOf(last.getPeriodLikeCount()));
+        }
+        return CursorDto.of(last.getPostId());
+    }
+
+    private PostListItemDto formatCreatedAt(PostListItemDto raw) {
+        return PostListItemDto.builder()
+                .postId(raw.getPostId())
+                .userId(raw.getUserId())
+                .nickname(raw.getNickname())
+                .profileImageId(raw.getProfileImageId())
+                .title(raw.getTitle())
+                .content(raw.getContent())
+                .thumbnailImageId(raw.getThumbnailImageId())
+                .isSpoiler(raw.getIsSpoiler())
+                .viewCount(raw.getViewCount())
+                .likeCount(raw.getLikeCount())
+                .commentCount(raw.getCommentCount())
+                .createdAt(LocalDateTime.parse(raw.getCreatedAt(), PARSER).format(FORMATTER))
+                .periodLikeCount(raw.getPeriodLikeCount())
+                .build();
+    }
+}

--- a/src/main/java/com/anipick/backend/community/service/CommunityPostService.java
+++ b/src/main/java/com/anipick/backend/community/service/CommunityPostService.java
@@ -1,0 +1,197 @@
+package com.anipick.backend.community.service;
+
+import com.anipick.backend.common.exception.CustomException;
+import com.anipick.backend.common.exception.ErrorCode;
+import com.anipick.backend.common.util.LocalizationUtil;
+import com.anipick.backend.community.domain.CommunityPost;
+import com.anipick.backend.community.dto.PostCreateRequest;
+import com.anipick.backend.community.dto.PostCreateResultDto;
+import com.anipick.backend.community.dto.PostDetailDto;
+import com.anipick.backend.community.dto.PostDetailRawDto;
+import com.anipick.backend.community.dto.PostUpdateRequest;
+import com.anipick.backend.community.mapper.CommunityBoardMapper;
+import com.anipick.backend.community.mapper.CommunityPostLikeMapper;
+import com.anipick.backend.community.mapper.CommunityPostMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommunityPostService {
+
+    private final CommunityPostMapper communityPostMapper;
+    private final CommunityPostLikeMapper communityPostLikeMapper;
+    private final CommunityBoardMapper communityBoardMapper;
+    private final RedissonClient redissonClient;
+
+    private static final DateTimeFormatter PARSER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy. MM. dd");
+
+    @Transactional
+    public PostCreateResultDto createPost(PostCreateRequest request, Long userId) {
+        request.validate();
+
+        if (!communityBoardMapper.existsSeries(request.getSeriesId())) {
+            throw new CustomException(ErrorCode.SERIES_NOT_FOUND);
+        }
+
+        CommunityPost post = CommunityPost.builder()
+                .seriesId(request.getSeriesId())
+                .userId(userId)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .isSpoiler(request.getSpoilerOrDefault())
+                .build();
+        communityPostMapper.insertPost(post);
+
+        List<Long> imageIds = request.getImageIds();
+        if (imageIds != null && !imageIds.isEmpty()) {
+            communityPostMapper.insertPostImages(post.getPostId(), imageIds);
+        }
+
+        return PostCreateResultDto.from(post.getPostId());
+    }
+
+    @Transactional
+    public PostDetailDto getPostDetail(Long postId, Long userId) {
+        // 조회수 1 증가 (삭제된 글은 UPDATE 조건에서 걸러져 증가하지 않음)
+        communityPostMapper.increaseViewCount(postId);
+
+        PostDetailRawDto raw = communityPostMapper.selectPostDetail(postId, userId);
+        if (raw == null) {
+            throw new CustomException(ErrorCode.COMMUNITY_POST_NOT_FOUND);
+        }
+
+        List<Long> imageIds = communityPostMapper.selectPostImageIds(postId);
+        String seriesTitle = LocalizationUtil.pickTitle(
+                null, raw.getSeriesTitleKor(), raw.getSeriesTitleEng(), raw.getSeriesTitleRom(), raw.getSeriesTitleNat());
+
+        return PostDetailDto.builder()
+                .postId(raw.getPostId())
+                .seriesId(raw.getSeriesId())
+                .seriesTitle(seriesTitle)
+                .userId(raw.getUserId())
+                .nickname(raw.getNickname())
+                .profileImageId(raw.getProfileImageId())
+                .title(raw.getTitle())
+                .content(raw.getContent())
+                .isSpoiler(raw.getIsSpoiler())
+                .imageIds(imageIds)
+                .viewCount(raw.getViewCount())
+                .likeCount(raw.getLikeCount())
+                .commentCount(raw.getCommentCount())
+                .isLiked(raw.getIsLiked())
+                .isMine(raw.getUserId().equals(userId))
+                .isAuthorBlocked(raw.getIsAuthorBlocked())
+                .createdAt(LocalDateTime.parse(raw.getCreatedAt(), PARSER).format(FORMATTER))
+                .build();
+    }
+
+    @Transactional
+    public void updatePost(Long postId, PostUpdateRequest request, Long userId) {
+        request.validate();
+
+        CommunityPost post = findActivePostOrThrow(postId);
+        if (!post.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.COMMUNITY_POST_NOT_OWNER);
+        }
+
+        communityPostMapper.updatePost(postId, userId, request);
+
+        // 첨부 이미지 전량 교체 (기존 매핑 삭제 후 재삽입)
+        communityPostMapper.deletePostImages(postId);
+        List<Long> imageIds = request.getImageIds();
+        if (imageIds != null && !imageIds.isEmpty()) {
+            communityPostMapper.insertPostImages(postId, imageIds);
+        }
+    }
+
+    @Transactional
+    public void deletePost(Long postId, Long userId) {
+        CommunityPost post = findActivePostOrThrow(postId);
+        if (!post.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.COMMUNITY_POST_NOT_OWNER);
+        }
+        // Soft delete. 댓글/대댓글은 그대로 유지.
+        communityPostMapper.softDeletePost(postId, userId);
+    }
+
+    @Transactional
+    public void likePost(Long userId, Long postId) {
+        findActivePostOrThrow(postId);
+
+        RLock lock = redissonClient.getLock("communityPost:" + postId + ":likeLock");
+        boolean isLocked = false;
+        try {
+            isLocked = lock.tryLock(1, TimeUnit.SECONDS);
+            if (!isLocked) {
+                log.error("락 획득 실패");
+                throw new CustomException(ErrorCode.GET_LOCK_FAILED);
+            }
+
+            try {
+                communityPostLikeMapper.insertLikePost(userId, postId);
+            } catch (DuplicateKeyException e) {
+                throw new CustomException(ErrorCode.ALREADY_LIKE_DATA);
+            }
+
+            communityPostMapper.increaseLikeCount(postId);
+        } catch (InterruptedException e) {
+            log.error("락 인터럽트 : {}", e.getMessage());
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        } finally {
+            if (isLocked) {
+                lock.unlock();
+            }
+        }
+    }
+
+    @Transactional
+    public void unlikePost(Long userId, Long postId) {
+        findActivePostOrThrow(postId);
+
+        RLock lock = redissonClient.getLock("communityPost:" + postId + ":likeLock");
+        boolean isLocked = false;
+        try {
+            isLocked = lock.tryLock(1, TimeUnit.SECONDS);
+            if (!isLocked) {
+                log.error("락 획득 실패");
+                throw new CustomException(ErrorCode.GET_LOCK_FAILED);
+            }
+
+            boolean isLiked = communityPostLikeMapper.selectUserLikePost(userId, postId);
+            if (!isLiked) {
+                throw new CustomException(ErrorCode.LIKE_DATA_NOT_FOUND);
+            }
+
+            communityPostLikeMapper.deleteLikePost(userId, postId);
+            communityPostMapper.decreaseLikeCount(postId);
+        } catch (InterruptedException e) {
+            log.error("락 인터럽트 : {}", e.getMessage());
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        } finally {
+            if (isLocked) {
+                lock.unlock();
+            }
+        }
+    }
+
+    private CommunityPost findActivePostOrThrow(Long postId) {
+        CommunityPost post = communityPostMapper.selectPostForCheck(postId);
+        if (post == null || post.getDeletedAt() != null) {
+            throw new CustomException(ErrorCode.COMMUNITY_POST_NOT_FOUND);
+        }
+        return post;
+    }
+}

--- a/src/main/java/com/anipick/backend/image/controller/ImageController.java
+++ b/src/main/java/com/anipick/backend/image/controller/ImageController.java
@@ -47,4 +47,14 @@ public class ImageController {
         ImageIdResponse response = imageService.updateProfileImage(user, profileImageFile);
         return ApiResponse.success(response);
     }
+
+    // 커뮤니티 게시글 첨부 이미지 업로드 (1회 호출당 1장). 반환한 imageId 를 게시글 작성 imageIds 에 포함.
+    @PostMapping("/community-post-image")
+    public ApiResponse<ImageIdResponse> uploadCommunityPostImage(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestPart("postImageFile") MultipartFile postImageFile
+    ) {
+        ImageIdResponse response = imageService.uploadCommunityPostImage(user, postImageFile);
+        return ApiResponse.success(response);
+    }
 }

--- a/src/main/java/com/anipick/backend/image/domain/Image.java
+++ b/src/main/java/com/anipick/backend/image/domain/Image.java
@@ -11,4 +11,5 @@ public class Image {
     private Long authId;
     private String imageName;
     private String imagePath;
+    private ImageType imageType;
 }

--- a/src/main/java/com/anipick/backend/image/domain/ImageType.java
+++ b/src/main/java/com/anipick/backend/image/domain/ImageType.java
@@ -1,0 +1,11 @@
+package com.anipick.backend.image.domain;
+
+/**
+ * image.image_type 컬럼 값. DB 에는 name() 그대로 저장된다(EnumTypeHandler).
+ * - PROFILE: 유저 프로필 이미지(유저당 1행 유지)
+ * - COMMUNITY_POST: 커뮤니티 게시글 첨부 이미지(유저당 다수 가능)
+ */
+public enum ImageType {
+    PROFILE,
+    COMMUNITY_POST
+}

--- a/src/main/java/com/anipick/backend/image/service/ImageService.java
+++ b/src/main/java/com/anipick/backend/image/service/ImageService.java
@@ -6,6 +6,7 @@ import com.anipick.backend.common.exception.ErrorCode;
 import com.anipick.backend.image.domain.DefaultImage;
 import com.anipick.backend.image.domain.Image;
 import com.anipick.backend.image.domain.ImageDefaults;
+import com.anipick.backend.image.domain.ImageType;
 import com.anipick.backend.image.dto.ImageIdResponse;
 import com.anipick.backend.image.mapper.ImageMapper;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +27,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +38,9 @@ public class ImageService {
     private String uploadDir;
 
     private final ImageMapper imageMapper;
+
+    private static final Set<String> COMMUNITY_IMAGE_ALLOWED_EXTENSIONS =
+            Set.of("png", "jpg", "jpeg", "heic");
 
     public File compressAndSaveImageToServer(CustomUserDetails user, MultipartFile imageFile) throws IOException {
         String originalFilename = imageFile.getOriginalFilename();
@@ -61,11 +67,12 @@ public class ImageService {
         return outputFile;
     }
 
-    public Image insertImage(CustomUserDetails user, String originalFilename, File outputFile) {
+    public Image insertImage(CustomUserDetails user, String originalFilename, File outputFile, ImageType imageType) {
         Image image = Image.builder()
                 .authId(user.getUserId())
                 .imageName(originalFilename)
                 .imagePath(outputFile.getAbsolutePath())
+                .imageType(imageType)
                 .build();
 
         imageMapper.insertImage(image);
@@ -110,12 +117,13 @@ public class ImageService {
                         .authId(user.getUserId())
                         .imageName(originalFilename)
                         .imagePath(outputFile.getAbsolutePath())
+                        .imageType(ImageType.PROFILE)
                         .build();
                 updateImage(updatedImage, user.getUserId());
 
                 return ImageIdResponse.from(updatedImage.getImageId());
             } else {
-                image = insertImage(user, originalFilename, outputFile);
+                image = insertImage(user, originalFilename, outputFile, ImageType.PROFILE);
 
                 return ImageIdResponse.from(image.getImageId());
             }
@@ -144,6 +152,70 @@ public class ImageService {
         Thumbnails.of(file.getInputStream())
                 .size(200, 200)
                 .outputQuality(0.7)
+                .toOutputStream(outputStream);
+
+        return outputStream.toByteArray();
+    }
+
+    /**
+     * 커뮤니티 게시글 첨부 이미지 업로드. 프로필과 달리 매번 새 image 행을 생성한다(게시글당 최대 5장).
+     * 용량 10MB 초과는 spring.servlet.multipart.max-file-size 설정에서 선차단되어
+     * MaxUploadSizeExceededException 으로 처리된다.
+     */
+    @Transactional
+    public ImageIdResponse uploadCommunityPostImage(CustomUserDetails user, MultipartFile postImageFile) {
+        validateCommunityImageExtension(postImageFile.getOriginalFilename());
+
+        try {
+            File outputFile = compressAndSaveCommunityImageToServer(user, postImageFile);
+            Image image = insertImage(user, postImageFile.getOriginalFilename(), outputFile, ImageType.COMMUNITY_POST);
+            return ImageIdResponse.from(image.getImageId());
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void validateCommunityImageExtension(String originalFilename) {
+        String extension = FilenameUtils.getExtension(
+                originalFilename == null ? "" : originalFilename).toLowerCase(Locale.ROOT);
+        if (!COMMUNITY_IMAGE_ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new CustomException(ErrorCode.INVAILD_IMAGE_EXTENSION);
+        }
+    }
+
+    private File compressAndSaveCommunityImageToServer(CustomUserDetails user, MultipartFile imageFile) throws IOException {
+        String originalFilename = imageFile.getOriginalFilename();
+
+        // TODO(image): heic 는 ImageIO 기본 디코더가 없어 read 결과가 null 이 된다.
+        //  현재는 확장자 허용 후 여기서 INVAILD_IMAGE_EXTENSION 으로 떨어짐. heic 지원 시 별도 디코더 필요.
+        BufferedImage bufferedImage = ImageIO.read(imageFile.getInputStream());
+        if (bufferedImage == null) {
+            throw new CustomException(ErrorCode.INVAILD_IMAGE_EXTENSION);
+        }
+
+        byte[] compressedBytes = compressCommunityImageWithThumbnailator(imageFile);
+        String uploadImageUrl = getUploadImageUrl(originalFilename, user.getUserId());
+
+        File directory = new File(uploadDir);
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
+
+        File outputFile = new File(directory, uploadImageUrl);
+        try (FileOutputStream fileOutputStream = new FileOutputStream(outputFile)) {
+            fileOutputStream.write(compressedBytes);
+        }
+
+        return outputFile;
+    }
+
+    // 게시글 이미지는 프로필(200x200 썸네일)과 달리 본문 표시용이므로 더 큰 해상도를 유지한다.
+    private byte[] compressCommunityImageWithThumbnailator(MultipartFile file) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        Thumbnails.of(file.getInputStream())
+                .size(1080, 1080)
+                .outputQuality(0.8)
                 .toOutputStream(outputStream);
 
         return outputStream.toByteArray();

--- a/src/main/resources/mapper/anime/AnimeQueryMapper.xml
+++ b/src/main/resources/mapper/anime/AnimeQueryMapper.xml
@@ -190,6 +190,7 @@
                     AND rl.user_id = #{userId}
             LEFT JOIN Image i
                 ON i.auth_id = u.user_id
+                    AND i.image_type = 'PROFILE'
         WHERE r.anime_id = #{animeId}
         AND r.content IS NOT NULL
         -- 소프트 삭제된 리뷰는 제외

--- a/src/main/resources/mapper/community/CommunityBoardQueryMapper.xml
+++ b/src/main/resources/mapper/community/CommunityBoardQueryMapper.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.anipick.backend.community.mapper.CommunityBoardMapper">
+
+    <!--
+        애니 ID 기준으로 게시판(시리즈) 매핑 여부까지 판단.
+        anime 를 기준으로 LEFT JOIN 하므로 매핑이 없어도 애니가 존재하면 1건 반환된다.
+        (seriesId == null → 게시판 없음, 프론트 팝업용. 애니 자체 값으로 fallback)
+        애니 자체가 없으면 0건 → 서비스에서 ANIME_NOT_FOUND.
+        series_anime 는 anime_id UNIQUE 이므로 매핑 존재 시에도 1건.
+    -->
+    <select id="selectBoardByAnimeId" resultType="com.anipick.backend.community.dto.BoardInfoRawDto">
+        SELECT s.series_id          AS seriesId,
+               s.title_kor          AS titleKor,
+               s.title_eng          AS titleEng,
+               s.title_rom          AS titleRom,
+               s.title_nat          AS titleNat,
+               s.cover_image_url    AS coverImageUrl,
+               a.title_kor_manual   AS animeTitleMan,
+               a.title_kor          AS animeTitleKor,
+               a.title_english      AS animeTitleEng,
+               a.title_romaj        AS animeTitleRom,
+               a.title_native       AS animeTitleNat,
+               a.cover_image_url    AS animeCoverImageUrl
+        FROM anime a
+                 LEFT JOIN series_anime sa ON sa.anime_id = a.anime_id
+                 LEFT JOIN series s ON s.series_id = sa.series_id
+        WHERE a.anime_id = #{animeId}
+    </select>
+
+    <!-- 시리즈 대표작(sort_order 최소 = 1기)의 장르. 시리즈엔 장르가 없어 대표작 기준. -->
+    <select id="selectRepresentativeGenresBySeriesId" resultType="com.anipick.backend.anime.dto.GenreDto">
+        SELECT g.genre_id  AS id,
+               g.genre_kor AS name
+        FROM animegenres ag
+                 JOIN genres g ON g.genre_id = ag.genre_id
+        WHERE ag.anime_id = (SELECT sa.anime_id
+                             FROM series_anime sa
+                             WHERE sa.series_id = #{seriesId}
+                             ORDER BY sa.sort_order ASC, sa.anime_id ASC
+                             LIMIT 1)
+    </select>
+
+    <!-- 게시판 없을 때(팝업용) 애니 자체 장르. -->
+    <select id="selectGenresByAnimeId" resultType="com.anipick.backend.anime.dto.GenreDto">
+        SELECT g.genre_id  AS id,
+               g.genre_kor AS name
+        FROM animegenres ag
+                 JOIN genres g ON g.genre_id = ag.genre_id
+        WHERE ag.anime_id = #{animeId}
+    </select>
+
+    <select id="countPostsBySeriesId" resultType="long">
+        SELECT COUNT(*)
+        FROM community_post
+        WHERE series_id = #{seriesId}
+          AND deleted_at IS NULL
+    </select>
+
+    <select id="existsSeries" resultType="boolean">
+        SELECT EXISTS(SELECT 1 FROM series WHERE series_id = #{seriesId})
+    </select>
+</mapper>

--- a/src/main/resources/mapper/community/CommunityPostCommandMapper.xml
+++ b/src/main/resources/mapper/community/CommunityPostCommandMapper.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.anipick.backend.community.mapper.CommunityPostMapper">
+
+    <insert id="insertPost" parameterType="com.anipick.backend.community.domain.CommunityPost"
+            useGeneratedKeys="true" keyProperty="postId">
+        INSERT INTO community_post
+            (series_id, user_id, title, content, is_spoiler, view_count, like_count, comment_count, created_at)
+        VALUES (#{seriesId}, #{userId}, #{title}, #{content}, #{isSpoiler}, 0, 0, 0, NOW())
+    </insert>
+
+    <!-- 첨부 이미지 벌크 삽입. image_order 는 배열 순서(0-based) + 1 = 1~5 -->
+    <insert id="insertPostImages">
+        INSERT INTO community_post_image
+            (post_id, image_id, image_order, created_at)
+        VALUES
+        <foreach collection="imageIds" item="imageId" index="idx" separator=",">
+            (#{postId}, #{imageId}, #{idx} + 1, NOW())
+        </foreach>
+    </insert>
+
+    <delete id="deletePostImages">
+        DELETE FROM community_post_image
+        WHERE post_id = #{postId}
+    </delete>
+
+    <update id="updatePost">
+        UPDATE community_post
+        SET title      = #{request.title},
+            content    = #{request.content},
+            is_spoiler = COALESCE(#{request.isSpoiler}, false),
+            updated_at = NOW()
+        WHERE post_id = #{postId}
+          AND user_id = #{userId}
+          AND deleted_at IS NULL
+    </update>
+
+    <update id="softDeletePost">
+        UPDATE community_post
+        SET deleted_at = NOW()
+        WHERE post_id = #{postId}
+          AND user_id = #{userId}
+          AND deleted_at IS NULL
+    </update>
+
+    <update id="increaseViewCount">
+        UPDATE community_post
+        SET view_count = view_count + 1
+        WHERE post_id = #{postId}
+          AND deleted_at IS NULL
+    </update>
+
+    <update id="increaseLikeCount">
+        UPDATE community_post
+        SET like_count = like_count + 1
+        WHERE post_id = #{postId}
+    </update>
+
+    <update id="decreaseLikeCount">
+        UPDATE community_post
+        SET like_count = like_count - 1
+        WHERE post_id = #{postId}
+          AND like_count &gt; 0
+    </update>
+</mapper>

--- a/src/main/resources/mapper/community/CommunityPostLikeCommandMapper.xml
+++ b/src/main/resources/mapper/community/CommunityPostLikeCommandMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.anipick.backend.community.mapper.CommunityPostLikeMapper">
+    <insert id="insertLikePost">
+        INSERT INTO community_post_like
+            (post_id, user_id, created_at)
+        VALUES (#{postId}, #{userId}, NOW())
+    </insert>
+
+    <delete id="deleteLikePost">
+        DELETE FROM community_post_like
+        WHERE user_id = #{userId}
+          AND post_id = #{postId}
+    </delete>
+</mapper>

--- a/src/main/resources/mapper/community/CommunityPostLikeQueryMapper.xml
+++ b/src/main/resources/mapper/community/CommunityPostLikeQueryMapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.anipick.backend.community.mapper.CommunityPostLikeMapper">
+    <select id="selectUserLikePost" resultType="boolean">
+        SELECT EXISTS(SELECT 1
+                      FROM community_post_like
+                      WHERE user_id = #{userId}
+                        AND post_id = #{postId})
+    </select>
+</mapper>

--- a/src/main/resources/mapper/community/CommunityPostQueryMapper.xml
+++ b/src/main/resources/mapper/community/CommunityPostQueryMapper.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.anipick.backend.community.mapper.CommunityPostMapper">
+
+    <!-- 프로필 이미지 = image.image_type = 'PROFILE' 인 이 유저의 image (유저당 1행 유지) -->
+    <sql id="profileImageIdSubquery">
+        (SELECT i.image_id
+         FROM image i
+         WHERE i.auth_id = p.user_id
+           AND i.image_type = 'PROFILE'
+         ORDER BY i.image_id ASC
+         LIMIT 1)
+    </sql>
+
+    <!-- 게시글 대표 썸네일 = image_order 가 가장 앞선 첨부 이미지 -->
+    <sql id="thumbnailImageIdSubquery">
+        (SELECT cpi.image_id
+         FROM community_post_image cpi
+         WHERE cpi.post_id = p.post_id
+         ORDER BY cpi.image_order ASC
+         LIMIT 1)
+    </sql>
+
+    <!-- 차단한 유저의 게시글 제외 -->
+    <sql id="blockFilter">
+        AND NOT EXISTS (SELECT 1
+                        FROM blockeduser bu
+                        WHERE bu.blocked_user_id = p.user_id
+                          AND bu.user_id = #{userId})
+    </sql>
+
+    <select id="countBoardPosts" resultType="long">
+        SELECT COUNT(*)
+        FROM community_post p
+        WHERE p.series_id = #{seriesId}
+          AND p.deleted_at IS NULL
+        <include refid="blockFilter"/>
+    </select>
+
+    <!-- 최신순: post_id DESC (autoincrement 라 생성 시각과 동일 순서) -->
+    <select id="selectLatestPosts" resultType="com.anipick.backend.community.dto.PostListItemDto">
+        SELECT p.post_id                     AS postId,
+               p.user_id                     AS userId,
+               u.nickname                    AS nickname,
+               <include refid="profileImageIdSubquery"/>   AS profileImageId,
+               p.title                       AS title,
+               p.content                     AS content,
+               <include refid="thumbnailImageIdSubquery"/> AS thumbnailImageId,
+               p.is_spoiler                  AS isSpoiler,
+               p.view_count                  AS viewCount,
+               p.like_count                  AS likeCount,
+               p.comment_count               AS commentCount,
+               p.created_at                  AS createdAt
+        FROM community_post p
+                 JOIN user u ON u.user_id = p.user_id
+        WHERE p.series_id = #{seriesId}
+          AND p.deleted_at IS NULL
+        <include refid="blockFilter"/>
+        <if test="lastId != null">
+            AND p.post_id &lt; #{lastId}
+        </if>
+        ORDER BY p.post_id DESC
+        LIMIT #{size}
+    </select>
+
+    <!--
+        인기순: 기간 내(created_at &gt;= periodStart) 좋아요 수로 정렬.
+        커서 = (periodLikeCount, post_id). 동점이면 post_id 낮은 순으로 이어붙임.
+    -->
+    <select id="selectPopularPosts" resultType="com.anipick.backend.community.dto.PostListItemDto">
+        SELECT p.post_id                     AS postId,
+               p.user_id                     AS userId,
+               u.nickname                    AS nickname,
+               <include refid="profileImageIdSubquery"/>   AS profileImageId,
+               p.title                       AS title,
+               p.content                     AS content,
+               <include refid="thumbnailImageIdSubquery"/> AS thumbnailImageId,
+               p.is_spoiler                  AS isSpoiler,
+               p.view_count                  AS viewCount,
+               p.like_count                  AS likeCount,
+               p.comment_count               AS commentCount,
+               p.created_at                  AS createdAt,
+               COALESCE(pl.periodCnt, 0)     AS periodLikeCount
+        FROM community_post p
+                 JOIN user u ON u.user_id = p.user_id
+                 LEFT JOIN (SELECT post_id, COUNT(*) AS periodCnt
+                            FROM community_post_like
+                            WHERE created_at &gt;= #{periodStart}
+                            GROUP BY post_id) pl ON pl.post_id = p.post_id
+        WHERE p.series_id = #{seriesId}
+          AND p.deleted_at IS NULL
+        <include refid="blockFilter"/>
+        <!-- lastId/lastValue 는 서비스에서 둘 다 있거나 둘 다 없도록 보장(한쪽만 오면 BAD_REQUEST) -->
+        <if test="lastId != null and lastValue != null">
+            AND (
+                COALESCE(pl.periodCnt, 0) &lt; #{lastValue}
+                OR (COALESCE(pl.periodCnt, 0) = #{lastValue} AND p.post_id &lt; #{lastId})
+            )
+        </if>
+        ORDER BY periodLikeCount DESC, p.post_id DESC
+        LIMIT #{size}
+    </select>
+
+    <select id="selectPostDetail" resultType="com.anipick.backend.community.dto.PostDetailRawDto">
+        SELECT p.post_id       AS postId,
+               p.series_id     AS seriesId,
+               s.title_kor     AS seriesTitleKor,
+               s.title_eng     AS seriesTitleEng,
+               s.title_rom     AS seriesTitleRom,
+               s.title_nat     AS seriesTitleNat,
+               p.user_id       AS userId,
+               u.nickname      AS nickname,
+               <include refid="profileImageIdSubquery"/> AS profileImageId,
+               p.title         AS title,
+               p.content       AS content,
+               p.is_spoiler    AS isSpoiler,
+               p.view_count    AS viewCount,
+               p.like_count    AS likeCount,
+               p.comment_count AS commentCount,
+               CASE WHEN cpl.post_like_id IS NOT NULL THEN TRUE ELSE FALSE END AS isLiked,
+               CASE WHEN bu.user_id IS NOT NULL THEN TRUE ELSE FALSE END       AS isAuthorBlocked,
+               p.created_at    AS createdAt
+        FROM community_post p
+                 JOIN user u ON u.user_id = p.user_id
+                 JOIN series s ON s.series_id = p.series_id
+                 LEFT JOIN community_post_like cpl
+                           ON cpl.post_id = p.post_id AND cpl.user_id = #{userId}
+                 LEFT JOIN blockeduser bu
+                           ON bu.blocked_user_id = p.user_id AND bu.user_id = #{userId}
+        WHERE p.post_id = #{postId}
+          AND p.deleted_at IS NULL
+    </select>
+
+    <select id="selectPostImageIds" resultType="long">
+        SELECT cpi.image_id
+        FROM community_post_image cpi
+        WHERE cpi.post_id = #{postId}
+        ORDER BY cpi.image_order ASC
+    </select>
+
+    <select id="selectPostForCheck" resultType="com.anipick.backend.community.domain.CommunityPost">
+        SELECT post_id    AS postId,
+               series_id  AS seriesId,
+               user_id    AS userId,
+               deleted_at AS deletedAt
+        FROM community_post
+        WHERE post_id = #{postId}
+    </select>
+</mapper>

--- a/src/main/resources/mapper/image/ImageCommandMapper.xml
+++ b/src/main/resources/mapper/image/ImageCommandMapper.xml
@@ -5,9 +5,9 @@
 <mapper namespace="com.anipick.backend.image.mapper.ImageMapper">
     <insert id="insertImage" parameterType="com.anipick.backend.image.domain.Image" useGeneratedKeys="true" keyProperty="imageId">
         INSERT INTO Image
-            (auth_id, image_name, image_path)
+            (auth_id, image_name, image_path, image_type)
         VALUES
-            (#{authId}, #{imageName}, #{imagePath})
+            (#{authId}, #{imageName}, #{imagePath}, #{imageType})
     </insert>
 
     <update id="updateImageByUserId" parameterType="com.anipick.backend.image.domain.Image">
@@ -16,6 +16,7 @@
             image_name = #{image.imageName},
             image_path = #{image.imagePath}
         WHERE auth_id = #{userId}
+          AND image_type = 'PROFILE'
     </update>
 
     <delete id="deleteImage">

--- a/src/main/resources/mapper/image/ImageQueryMapper.xml
+++ b/src/main/resources/mapper/image/ImageQueryMapper.xml
@@ -21,5 +21,6 @@
             i.image_path AS imagePath
         FROM Image AS i
         WHERE auth_id = #{userId}
+          AND i.image_type = 'PROFILE'
     </select>
 </mapper>

--- a/src/main/resources/mapper/review/RecentReviewQueryMapper.xml
+++ b/src/main/resources/mapper/review/RecentReviewQueryMapper.xml
@@ -50,6 +50,7 @@
         AND rl.user_id = #{currentUserId}
         LEFT JOIN Image i
         ON i.auth_id = u.user_id
+        AND i.image_type = 'PROFILE'
         WHERE r.is_spoiler = FALSE
         AND r.content IS NOT NULL
         -- 소프트 삭제된 리뷰는 제외


### PR DESCRIPTION
### Change Cause : 
애니 시리즈 단위 커뮤니티 게시판과 게시글 CRUD/좋아요 기능이 필요해 신규 구현했습니다.
게시글 이미지 첨부를 위해 기존 image 테이블에 image_type(PROFILE / COMMUNITY_POST)을 도입하고,
프로필 이미지를 조회하던 기존 쿼리에 image_type = 'PROFILE' 조건을 함께 보강했습니다.


---

**work-details**

**게시판 (`/api/community/boards`)**
- `GET /by-anime/{animeId}` : 애니 → 매핑된 시리즈 게시판 조회. 매핑이 없으면 `hasBoard=false`로 애니 자체 정보(제목/커버/장르)를 fallback으로 내려 프론트 팝업에 사용
- `GET /{seriesId}/posts` : 게시글 목록. `sort=latest | popularDaily | popularWeekly | popularMonthly` 커서 페이징
  - 최신순은 `post_id` 커서, 인기순은 `(기간 내 좋아요 수, post_id)` 복합 커서
  - 인기순은 `community_post_like.created_at`이 기간 시작 이후인 것만 집계
  - 차단한 유저의 게시글은 목록/카운트 모두에서 제외

**게시글 (`/api/community/posts`)**
- `POST /` : 작성 (제목 1~50자, 내용 1~1000자, 이미지 최대 5장)
- `GET /{postId}` : 상세 (조회수 +1, `isLiked` / `isMine` / `isAuthorBlocked` 포함)
- `PATCH /{postId}` : 수정 (작성자 본인만, 첨부 이미지는 전량 교체)
- `DELETE /{postId}` : soft delete (댓글/대댓글은 유지)
- `POST|DELETE /{postId}/like` : 좋아요 등록/취소. Redisson 분산 락 + `community_post_like` UNIQUE 제약으로 중복 방지

**이미지**
- `POST /api/image/community-post-image` : 게시글 첨부 이미지 업로드 (1회 1장)
  - 허용 확장자 png/jpg/jpeg/heic, 1080x1080 / quality 0.8 (프로필은 200x200 유지)
  - 10MB 초과는 `MaxUploadSizeExceededException` 핸들러에서 `IMAGE_SIZE_EXCEEDED`로 응답
- `image.image_type` 추가에 따라 프로필 이미지 조회 쿼리에 `image_type = 'PROFILE'` 조건 보강
  (`ImageQueryMapper`, `ImageCommandMapper`, `AnimeQueryMapper`, `RecentReviewQueryMapper`)

**ErrorCode 추가**
- 903 `IMAGE_SIZE_EXCEEDED`
- 1001~1007 `ANIME_NOT_FOUND`, `SERIES_NOT_FOUND`, `COMMUNITY_POST_NOT_FOUND`, `COMMUNITY_POST_NOT_OWNER`, `COMMUNITY_POST_TITLE_LENGTH_INVALID`, `COMMUNITY_POST_CONTENT_LENGTH_INVALID`, `COMMUNITY_POST_IMAGE_COUNT_EXCEEDED`

**참고 (후속 작업)**
- 댓글/신고는 테이블만 존재하고 미구현이라 `comment_count`는 현재 항상 0입니다
- 게시글에 첨부되지 않은 이미지의 정리 로직은 아직 없습니다
- 조회 성능을 위해 인덱스 2개 추가를 검토 중입니다
  - `image (auth_id, image_type)` : 프로필 이미지 서브쿼리가 목록 행마다 image 전체 스캔
  - `community_post (series_id, post_id DESC)` : 최신순 정렬이 filesort로 처리됨

**Screenshot**

### Test Check List ✔️
- [ ] Test Code
- [x] API Test
